### PR TITLE
HW14

### DIFF
--- a/kubernetes-prod/README.MD
+++ b/kubernetes-prod/README.MD
@@ -1,0 +1,440 @@
+/--------------------------------------------------------------
+# akharc_platform
+akharc Platform repository
+# Выполнено ДЗ №14
+
+ - [ ] Основное ДЗ
+ - [ ] Задание со * 
+
+
+## В процессе сделано:
+ - развернут кластер версии 1.23 и затем обновлен
+ - развернут кластер через kubespray
+
+
+
+## Как проверить работоспособность:
+
+### Готовим инфраструктуру:
+
+- Настраиваем терраформ на работу с ЯОблаком
+``` shell
+yc iam key create \
+  --service-account-id <идентификатор_сервисного_аккаунта> \
+  --folder-name <имя_каталога_с_сервисным_аккаунтом> \
+  --output key.json
+
+id: *значение*
+service_account_id: *значение*
+created_at: "2024-02-24T12:22:14.241173512Z"
+key_algorithm: RSA_2048
+
+[akha@192 ~]$ yc config profile create akha-k8s-tf
+Profile 'akha-k8s-tf' created and activated
+
+yc config set service-account-key key.json
+yc config set cloud-id *значение*
+yc config set folder-id *значение*
+
+export YC_TOKEN=$(yc iam create-token)
+export YC_CLOUD_ID=$(yc config get cloud-id)
+export YC_FOLDER_ID=$(yc config get folder-id)
+```
+
+- выбираем образ    
+``` shell
+yc compute image list --folder-id standard-images  | grep ubuntu-20-04
+
+export PATH=$PATH:/usr/local/src
+
+| fd85an6q1o26nf37i2nl | ubuntu-20-04-lts-v20231218                                 | ubuntu-2004-lts                                 | f2ekp29fd7vk7pke4hj5           | READY  |
+```
+ - далее ставим Terraform из зеркала Яндекса, делаем terraform init и разворачиваем ноды
+``` shell
+[akha@192 tf]$ terraform init
+
+[akha@192 tf]$ terraform plan
+[akha@192 tf]$ terraform apply --auto-approve
+
+master_hostname = "master"
+master_private_ip = "192.168.1.100"
+master_public_ip = "XXXX"
+worker_nodes_hostnames = [
+  "worker-1",
+  "worker-2",
+  "worker-3",
+]
+worker_nodes_private_ips = [
+  "192.168.1.201",
+  "192.168.1.202",
+  "192.168.1.203",
+]
+``` 
+
+ - Настраиваем подключение по ssh к мастер-ноде и к воркерам, мастер выступает в роли jump-хоста
+добавляем в ~/.ssh/config параметры подключения к мастеру и заходим на него
+``` shell
+echo 'ip-addr master kubernetes' | sudo tee -a /etc/hosts
+ssh master
+``` 
+на мастере добавляем в ~/.ssh/config параметры подключения к воркерам, подкидывваем ssh-ключ и правим /etc/hosts
+``` shell
+# Your system has configured 'manage_etc_hosts' as True.
+# As a result, if you wish for changes to this file to persist
+# then you will need to either
+# a.) make changes to the master file in /etc/cloud/templates/hosts.debian.tmpl
+# b.) change or remove the value of 'manage_etc_hosts' in
+#     /etc/cloud/cloud.cfg or cloud-config from user-data
+#
+127.0.1.1 master.ru-central1.internal master
+127.0.0.1 localhost
+
+# The following lines are desirable for IPv6 capable hosts
+::1 localhost ip6-localhost ip6-loopback
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+192.168.1.100 master
+192.168.1.201 worker-1
+192.168.1.202 worker-2
+192.168.1.203 worker-3
+```
+
+далее актуализируем /etc/hosts на воркерах
+
+### Подготовка машин
+
+####Отключаем свап
+```shell
+ubuntu@master:~$ sudo sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
+ubuntu@master:~$ sudo swapoff -a
+```
+#### Загрузим br_netfilter и позволим iptables видеть трафик.
+
+на всех машинах:
+```shell
+$ cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
+EOF
+
+$ sudo modprobe overlay
+$ sudo modprobe br_netfilter
+
+$ cat <<EOF | sudo tee /etc/sysctl.d/kubernetes.conf
+net.bridge.bridge-nf-call-iptables=1 
+net.ipv4.ip_forward=1 
+net.bridge.bridge-nf-call-ip6tables=1 
+EOF
+
+$ sudo sysctl --system
+```
+#### Установим Containerd
+на всех машинах:
+```shell
+$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+$ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+$ sudo apt update -y
+$ sudo apt install -y containerd.io
+$ sudo mkdir -p /etc/containerd
+$ containerd config default | sudo tee /etc/containerd/config.toml
+$ sudo systemctl restart containerd && sudo systemctl enable containerd
+```
+#### Установка kubectl, kubeadm, kubelet
+на всех машинах:
+```shell
+$ sudo apt-get update && sudo apt-get install -y apt-transport-https curl
+$ curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+$ echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+$ sudo apt update -y
+$ sudo apt -y install vim git curl wget kubelet=1.23.0-00 kubeadm=1.23.0-00 kubectl=1.23.0-00
+$ sudo apt-mark hold kubelet kubeadm kubectl
+$ sudo kubeadm config images pull --cri-socket /run/containerd/containerd.sock --kubernetes-version v1.23.0
+```
+
+### Создание кластера
+
+на мастер-ноде
+``` shell
+sudo kubeadm init \
+  --apiserver-cert-extra-sans 62.84.119.214 \
+  --pod-network-cidr=10.244.0.0/16 \
+  --upload-certs \
+  --kubernetes-version=v1.23.0 \
+  --cri-socket /run/containerd/containerd.sock
+
+...  
+Your Kubernetes control-plane has initialized successfully!
+
+To start using your cluster, you need to run the following as a regular user:
+
+  mkdir -p $HOME/.kube
+  sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+  sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+Alternatively, if you are the root user, you can run:
+
+  export KUBECONFIG=/etc/kubernetes/admin.conf
+
+You should now deploy a pod network to the cluster.
+Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
+  https://kubernetes.io/docs/concepts/cluster-administration/addons/
+
+Then you can join any number of worker nodes by running the following on each as root:
+```
+```shell
+kubeadm join 192.168.1.100:6443 --token token \
+        --discovery-token-ca-cert-hash sha256:hash
+```
+ - Копируем конфиг kubectl
+```shell
+mkdir -p $HOME/.kube
+sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+[akha@192 .kube]$ kubectl cluster-info
+Kubernetes control plane is running at https://master:6443
+CoreDNS is running at https://master:6443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+
+To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
+```shell
+
+#### Установим сетевой плагин
+```shell
+ubuntu@master:~$ kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml
+namespace/kube-flannel created
+clusterrole.rbac.authorization.k8s.io/flannel created
+clusterrolebinding.rbac.authorization.k8s.io/flannel created
+serviceaccount/flannel created
+configmap/kube-flannel-cfg created
+daemonset.apps/kube-flannel-ds created
+
+ubuntu@master:~$ kubectl get nodes -o wide
+NAME     STATUS   ROLES                  AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
+master   Ready 
+```
+#### Подключаем worker-ноды
+
+получаем токен на мастере:
+```shell
+ubuntu@master:~$ sudo kubeadm token create --print-join-command
+```
+Выполняем на каждом воркере:
+```shell
+sudo kubeadm join master:6443 --token токен --discovery-token-ca-cert-hash sha256:хешш
+
+ubuntu@master:~$ kubectl get nodes -o wide
+NAME       STATUS 
+master     Ready    
+worker-1   Ready    
+worker-2   Ready    
+worker-3   Ready 
+```shell
+#### Запуск нагрузки
+```shell
+[akha@192 kubernetes-prod]$ kubectl apply -f nginx.yaml
+[akha@192 kubernetes-prod]$ kubectl get pods -o wide
+NAME                             READY   STATUS    RESTARTS   AGE   IP           NODE       NOMINATED NODE   READINESS GATES
+nginx-deployment-8c9c5f4-6xq64   1/1     Running   0          33s   10.244.1.2   worker-1   <none>           <none>
+nginx-deployment-8c9c5f4-pnsx4   1/1     Running   0          33s   10.244.2.2   worker-2   <none>           <none>
+nginx-deployment-8c9c5f4-qczr9   1/1     Running   0          33s   10.244.3.2   worker-3   <none>           <none>
+nginx-deployment-8c9c5f4-zdtcz   1/1     Running   0          33s   10.244.3.3   worker-3   <none>           <none>
+```
+### Обновление кластера
+Сперва мастер, затем - воркеры
+#### Обновление мастера
+```shell
+$ sudo apt update
+$ apt-cache madison kubeadm
+$ sudo apt-get install kubeadm='1.24.17-00' \
+  -y \
+  --allow-change-held-packages
+$ sudo kubeadm upgrade plan
+$ sudo kubeadm upgrade apply v1.24.17
+[upgrade/successful] SUCCESS! Your cluster was upgraded to "v1.24.17". Enjoy!
+
+[upgrade/kubelet] Now that your control plane is upgraded, please proceed with upgrading your kubelets if you haven't already done so.
+```
+
+Версия kubelet не изменилась
+```shell
+ubuntu@master:~$ kubectl get nodes
+NAME       STATUS   ROLES           AGE     VERSION
+master     Ready    control-plane   2d22h   v1.23.0
+worker-1   Ready    <none>          2d22h   v1.23.0
+worker-2   Ready    <none>          2d22h   v1.23.0
+worker-3   Ready    <none>          2d22h   v1.23.0
+```shell
+Версия Api изменилась:
+```shell
+ubuntu@master:~$ kubectl version
+Server Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.17"
+```
+#### Обновление остальных компонентов кластера
+```shell
+root@master:/home/ubuntu# kubeadm upgrade plan
+...
+[upgrade/versions] Target version: v1.24.17
+[upgrade/versions] Latest version in the v1.24 series: v1.24.17
+```
+ - применяем изменения:
+```shell
+kubeadm upgrade apply v1.24.17
+[upgrade/successful] SUCCESS! Your cluster was upgraded to "v1.24.17". Enjoy!
+root@master:/home/ubuntu# kubeadm version
+kubeadm version: &version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.17", GitCommit:"22a9682c8fe855c321be75c5faacde343f909b04", GitTreeState:"clean", BuildDate:"2023-08-23T23:43:11Z", GoVersion:"go1.20.7", Compiler:"gc", Platform:"linux/amd64"}
+root@master:/home/ubuntu# kubelet --version
+Kubernetes v1.23.0
+```
+ - Обновим kubelet
+```shell
+sudo apt-get install kubelet='1.24.17-00' kubectl='1.24.17-00' \
+  -y \
+  --allow-change-held-packages 
+sudo systemctl daemon-reload
+sudo systemctl restart kubelet
+ubuntu@master:~$ kubectl get nodes
+NAME       STATUS   ROLES           AGE     VERSION
+master     Ready    control-plane   2d22h   v1.24.17
+worker-1   Ready    <none>          2d22h   v1.23.0
+worker-2   Ready    <none>          2d22h   v1.23.0
+worker-3   Ready    <none>          2d22h   v1.23.0
+```
+#### Обновление worker nodes
+
+Операции выполняем на каждой из worker нод. Обновляем по очереди, сначала полностью одну ноду, и, после ее ввода в срой, - обновляем следующую.
+
+снимаем нагрузку с ноды:
+```shell
+[akha@192 ~]$ kubectl drain worker-1 --ignore-daemonsets
+
+...
+node/worker-1 drained
+[akha@192 ~]$ kubectl get nodes
+NAME       STATUS                     ROLES           AGE     VERSION
+master     Ready                      control-plane   2d23h   v1.24.17
+worker-1   Ready,SchedulingDisabled   <none>          2d22h   v1.23.0
+```
+
+Обновляем kubeadm:
+```shell
+$ sudo apt update
+$ apt-cache madison kubeadm
+$ sudo apt-get install kubeadm='1.24.17-00' \
+  -y \
+  --allow-change-held-packages
+$ sudo kubeadm upgrade node
+[upgrade] The configuration for this node was successfully updated!
+```
+обновляем kubelet
+```shell
+$ sudo apt-get install kubelet='1.24.17-00' kubectl='1.24.17-00' \
+  -y \
+  --allow-change-held-packages
+$ sudo systemctl daemon-reload
+$ sudo systemctl restart kubelet
+```
+возвращаем нагрузку
+```shell
+[akha@192 ~]$ kubectl uncordon worker-1
+node/worker-1 uncordoned
+```
+Смотрим результат
+
+```shell
+[akha@192 ~]$ kubectl get nodes
+NAME       STATUS   ROLES           AGE     VERSION
+master     Ready    control-plane   2d23h   v1.24.17
+worker-1   Ready    <none>          2d23h   v1.24.17
+worker-2   Ready    <none>          2d22h   v1.23.0
+worker-3   Ready    <none>          2d22h   v1.23.0
+```
+повторяем на оставшихся двух нодах.
+```shell
+[akha@192 ~]$ kubectl get nodes
+NAME       STATUS   ROLES           AGE     VERSION
+master     Ready    control-plane   2d23h   v1.24.17
+worker-1   Ready    <none>          2d23h   v1.24.17
+worker-2   Ready    <none>          2d23h   v1.24.17
+worker-3   Ready    <none>          2d23h   v1.24.17
+```
+### Автоматическое развертывание кластеров
+
+Ставим python и pip
+```shell
+[akha@192 ~]$ sudo yum-install python3
+[akha@192 ~]$ sudo yum install pip
+[akha@192 ~]$ python3 -V
+Python 3.9.18
+[akha@192 ~]$ pip -V
+pip 21.2.3 from /usr/lib/python3.9/site-packages/pip (python 3.9)
+[akha@192 ~]$ pip3 install virtualenv
+```
+Пересоздаем ноды терраформом, назначем им внешние адреса.
+SSH доступ на все ноды кластера - аналогично ручному развертыванию. 
+#### Установка Kubespray
+```shell
+[akha@192 ~]$ git clone https://github.com/kubernetes-sigs/kubespray.git
+[akha@192 kubespray]$ sudo pip install -r requirements.txt
+[akha@192 kubespray]$ ansible --version
+ansible [core 2.15.9]
+  config file = /home/akha/kubespray/ansible.cfg
+  configured module search path = ['/home/akha/kubespray/library']
+  ansible python module location = /usr/local/lib/python3.9/site-packages/ansible
+  ansible collection location = /home/akha/.ansible/collections:/usr/share/ansible/collections
+  executable location = /usr/local/bin/ansible
+  python version = 3.9.18 (main, Jan 24 2024, 00:00:00) [GCC 11.4.1 20231218 (Red Hat 11.4.1-3)] (/usr/bin/python3)
+  jinja version = 3.1.2
+  libyaml = True
+```
+ - копируем и правим iventory
+```shell
+mkdir -p kubernetes-prod/inventory/
+```
+Запускаем созадние кластера
+```shell
+ansible-playbook \
+  -i ~/kubernetes-prod/inventory/inventory.ini \
+  --become \
+  --become-user=root \
+  --user=ubuntu \
+  --key-file=/home/akha/.ssh/akha-yc cluster.yml
+```
+ - A few moments later ...  
+```shell
+PLAY RECAP ***********************************************************************************************************************************************
+master                     : ok=698  changed=144  unreachable=0    failed=0    skipped=1165 rescued=0    ignored=6
+worker-1                   : ok=438  changed=88   unreachable=0    failed=0    skipped=697  rescued=0    ignored=1
+worker-2                   : ok=438  changed=88   unreachable=0    failed=0    skipped=693  rescued=0    ignored=1
+worker-3                   : ok=438  changed=88   unreachable=0    failed=0    skipped=693  rescued=0    ignored=1
+```
+ - Далее на мастере настраиваем конфиг:
+```shell
+mkdir -p $HOME/.kube
+sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo chown $(id -u):$(id -g) $HOME/.kube/config
+```
+ - и получаем инфу о нодах:
+```shell
+ubuntu@master:~$ kubectl get nodes -o wide
+NAME       STATUS   ROLES           AGE     VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
+master     Ready    control-plane   8m35s   v1.29.2   192.168.1.100   <none>        Ubuntu 20.04.6 LTS   5.4.0-169-generic   containerd://1.7.13
+worker-1   Ready    <none>          7m54s   v1.29.2   192.168.1.201   <none>        Ubuntu 20.04.6 LTS   5.4.0-169-generic   containerd://1.7.13
+worker-2   Ready    <none>          7m54s   v1.29.2   192.168.1.202   <none>        Ubuntu 20.04.6 LTS   5.4.0-169-generic   containerd://1.7.13
+worker-3   Ready    <none>          7m49s   v1.29.2   192.168.1.203   <none>        Ubuntu 20.04.6 LTS   5.4.0-169-generic   containerd://1.7.13
+```shell
+ - Подаем нагрузку и проверяем успешность:
+```shell
+[akha@192 kubernetes-prod]$ kubectl apply -f nginx.yaml
+deployment.apps/nginx-deployment created
+
+[akha@192 kubernetes-prod]$ kubectl get po -o wide
+NAME                                READY   STATUS    RESTARTS   AGE   IP               NODE       NOMINATED NODE   READINESS GATES
+nginx-deployment-54b6986c8c-9c25d   1/1     Running   0          79s   10.233.105.194   worker-1   <none>           <none>
+nginx-deployment-54b6986c8c-9wkx5   1/1     Running   0          79s   10.233.72.193    worker-2   <none>           <none>
+nginx-deployment-54b6986c8c-v5ngp   1/1     Running   0          79s   10.233.72.194    worker-2   <none>           <none>
+nginx-deployment-54b6986c8c-zt5lk   1/1     Running   0          79s   10.233.125.66    worker-3   <none>           <none>
+
+```shell
+
+## PR checklist:
+ - [*] Выставлен label с темой домашнего задания

--- a/kubernetes-prod/inventory/inventory.ini
+++ b/kubernetes-prod/inventory/inventory.ini
@@ -1,0 +1,48 @@
+# ## Configure 'ip' variable to bind kubernetes services on a
+# ## different ip than the default iface
+# ## We should set etcd_member_name for etcd cluster. The node that is not a etcd member do not need to set the value, or can set the empty string value.
+[all]
+# node1 ansible_host=95.54.0.12  # ip=10.3.0.1 etcd_member_name=etcd1
+# node2 ansible_host=95.54.0.13  # ip=10.3.0.2 etcd_member_name=etcd2
+# node3 ansible_host=95.54.0.14  # ip=10.3.0.3 etcd_member_name=etcd3
+# node4 ansible_host=95.54.0.15  # ip=10.3.0.4 etcd_member_name=etcd4
+# node5 ansible_host=95.54.0.16  # ip=10.3.0.5 etcd_member_name=etcd5
+# node6 ansible_host=95.54.0.17  # ip=10.3.0.6 etcd_member_name=etcd6
+
+master   ansible_host=62.84.119.214 etcd_member_name=etcd1
+worker-1 ansible_host=62.84.127.35 
+worker-2 ansible_host=158.160.116.221
+worker-3 ansible_host=158.160.40.177
+# ## configure a bastion host if your nodes are not directly reachable
+# [bastion]
+# bastion ansible_host=x.x.x.x ansible_user=some_user
+ansible_host=62.84.119.214 ansible_user=ubuntu
+
+[kube_control_plane]
+# node1
+# node2
+# node3
+master
+
+[etcd]
+# node1
+# node2
+# node3
+master
+
+[kube_node]
+# node2
+# node3
+# node4
+# node5
+# node6
+worker-1
+worker-2
+worker-3
+
+[calico_rr]
+
+[k8s_cluster:children]
+kube_control_plane
+kube_node
+calico_rr

--- a/kubernetes-prod/inventory/sample/group_vars/all/all.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/all.yml
@@ -1,0 +1,139 @@
+---
+## Directory where the binaries will be installed
+bin_dir: /usr/local/bin
+
+## The access_ip variable is used to define how other nodes should access
+## the node.  This is used in flannel to allow other flannel nodes to see
+## this node for example.  The access_ip is really useful AWS and Google
+## environments where the nodes are accessed remotely by the "public" ip,
+## but don't know about that address themselves.
+# access_ip: 1.1.1.1
+
+
+## External LB example config
+## apiserver_loadbalancer_domain_name: "elb.some.domain"
+# loadbalancer_apiserver:
+#   address: 1.2.3.4
+#   port: 1234
+
+## Internal loadbalancers for apiservers
+# loadbalancer_apiserver_localhost: true
+# valid options are "nginx" or "haproxy"
+# loadbalancer_apiserver_type: nginx  # valid values "nginx" or "haproxy"
+
+## Local loadbalancer should use this port
+## And must be set port 6443
+loadbalancer_apiserver_port: 6443
+
+## If loadbalancer_apiserver_healthcheck_port variable defined, enables proxy liveness check for nginx.
+loadbalancer_apiserver_healthcheck_port: 8081
+
+### OTHER OPTIONAL VARIABLES
+
+## By default, Kubespray collects nameservers on the host. It then adds the previously collected nameservers in nameserverentries.
+## If true, Kubespray does not include host nameservers in nameserverentries in dns_late stage. However, It uses the nameserver to make sure cluster installed safely in dns_early stage.
+## Use this option with caution, you may need to define your dns servers. Otherwise, the outbound queries such as www.google.com may fail.
+# disable_host_nameservers: false
+
+## Upstream dns servers
+# upstream_dns_servers:
+#   - 8.8.8.8
+#   - 8.8.4.4
+
+## There are some changes specific to the cloud providers
+## for instance we need to encapsulate packets with some network plugins
+## If set the possible values are either 'gce', 'aws', 'azure', 'openstack', 'vsphere', 'oci', or 'external'
+## When openstack is used make sure to source in the openstack credentials
+## like you would do when using openstack-client before starting the playbook.
+# cloud_provider:
+
+## When cloud_provider is set to 'external', you can set the cloud controller to deploy
+## Supported cloud controllers are: 'openstack', 'vsphere', 'huaweicloud' and 'hcloud'
+## When openstack or vsphere are used make sure to source in the required fields
+# external_cloud_provider:
+
+## Set these proxy values in order to update package manager and docker daemon to use proxies and custom CA for https_proxy if needed
+# http_proxy: ""
+# https_proxy: ""
+# https_proxy_cert_file: ""
+
+## Refer to roles/kubespray-defaults/defaults/main/main.yml before modifying no_proxy
+# no_proxy: ""
+
+## Some problems may occur when downloading files over https proxy due to ansible bug
+## https://github.com/ansible/ansible/issues/32750. Set this variable to False to disable
+## SSL validation of get_url module. Note that kubespray will still be performing checksum validation.
+# download_validate_certs: False
+
+## If you need exclude all cluster nodes from proxy and other resources, add other resources here.
+# additional_no_proxy: ""
+
+## If you need to disable proxying of os package repositories but are still behind an http_proxy set
+## skip_http_proxy_on_os_packages to true
+## This will cause kubespray not to set proxy environment in /etc/yum.conf for centos and in /etc/apt/apt.conf for debian/ubuntu
+## Special information for debian/ubuntu - you have to set the no_proxy variable, then apt package will install from your source of wish
+# skip_http_proxy_on_os_packages: false
+
+## Since workers are included in the no_proxy variable by default, docker engine will be restarted on all nodes (all
+## pods will restart) when adding or removing workers.  To override this behaviour by only including master nodes in the
+## no_proxy variable, set below to true:
+no_proxy_exclude_workers: false
+
+## Certificate Management
+## This setting determines whether certs are generated via scripts.
+## Chose 'none' if you provide your own certificates.
+## Option is  "script", "none"
+# cert_management: script
+
+## Set to true to allow pre-checks to fail and continue deployment
+# ignore_assert_errors: false
+
+## The read-only port for the Kubelet to serve on with no authentication/authorization. Uncomment to enable.
+# kube_read_only_port: 10255
+
+## Set true to download and cache container
+# download_container: true
+
+## Deploy container engine
+# Set false if you want to deploy container engine manually.
+# deploy_container_engine: true
+
+## Red Hat Enterprise Linux subscription registration
+## Add either RHEL subscription Username/Password or Organization ID/Activation Key combination
+## Update RHEL subscription purpose usage, role and SLA if necessary
+# rh_subscription_username: ""
+# rh_subscription_password: ""
+# rh_subscription_org_id: ""
+# rh_subscription_activation_key: ""
+# rh_subscription_usage: "Development"
+# rh_subscription_role: "Red Hat Enterprise Server"
+# rh_subscription_sla: "Self-Support"
+
+## Check if access_ip responds to ping. Set false if your firewall blocks ICMP.
+# ping_access_ip: true
+
+# sysctl_file_path to add sysctl conf to
+# sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"
+
+## Variables for webhook token auth https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+kube_webhook_token_auth: false
+kube_webhook_token_auth_url_skip_tls_verify: false
+# kube_webhook_token_auth_url: https://...
+## base64-encoded string of the webhook's CA certificate
+# kube_webhook_token_auth_ca_data: "LS0t..."
+
+## NTP Settings
+# Start the ntpd or chrony service and enable it at system boot.
+ntp_enabled: false
+ntp_manage_config: false
+ntp_servers:
+  - "0.pool.ntp.org iburst"
+  - "1.pool.ntp.org iburst"
+  - "2.pool.ntp.org iburst"
+  - "3.pool.ntp.org iburst"
+
+## Used to control no_log attribute
+unsafe_show_logs: false
+
+## If enabled it will allow kubespray to attempt setup even if the distribution is not supported. For unsupported distributions this can lead to unexpected failures in some cases.
+allow_unsupported_distribution_setup: false

--- a/kubernetes-prod/inventory/sample/group_vars/all/aws.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/aws.yml
@@ -1,0 +1,9 @@
+## To use AWS EBS CSI Driver to provision volumes, uncomment the first value
+## and configure the parameters below
+# aws_ebs_csi_enabled: true
+# aws_ebs_csi_enable_volume_scheduling: true
+# aws_ebs_csi_enable_volume_snapshot: false
+# aws_ebs_csi_enable_volume_resizing: false
+# aws_ebs_csi_controller_replicas: 1
+# aws_ebs_csi_plugin_image_tag: latest
+# aws_ebs_csi_extra_volume_tags: "Owner=owner,Team=team,Environment=environment'

--- a/kubernetes-prod/inventory/sample/group_vars/all/azure.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/azure.yml
@@ -1,0 +1,40 @@
+## When azure is used, you need to also set the following variables.
+## see docs/azure.md for details on how to get these values
+
+# azure_cloud:
+# azure_tenant_id:
+# azure_subscription_id:
+# azure_aad_client_id:
+# azure_aad_client_secret:
+# azure_resource_group:
+# azure_location:
+# azure_subnet_name:
+# azure_security_group_name:
+# azure_security_group_resource_group:
+# azure_vnet_name:
+# azure_vnet_resource_group:
+# azure_route_table_name:
+# azure_route_table_resource_group:
+# supported values are 'standard' or 'vmss'
+# azure_vmtype: standard
+
+## Azure Disk CSI credentials and parameters
+## see docs/azure-csi.md for details on how to get these values
+
+# azure_csi_tenant_id:
+# azure_csi_subscription_id:
+# azure_csi_aad_client_id:
+# azure_csi_aad_client_secret:
+# azure_csi_location:
+# azure_csi_resource_group:
+# azure_csi_vnet_name:
+# azure_csi_vnet_resource_group:
+# azure_csi_subnet_name:
+# azure_csi_security_group_name:
+# azure_csi_use_instance_metadata:
+# azure_csi_tags: "Owner=owner,Team=team,Environment=environment'
+
+## To enable Azure Disk CSI, uncomment below
+# azure_csi_enabled: true
+# azure_csi_controller_replicas: 1
+# azure_csi_plugin_image_tag: latest

--- a/kubernetes-prod/inventory/sample/group_vars/all/containerd.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/containerd.yml
@@ -1,0 +1,46 @@
+---
+# Please see roles/container-engine/containerd/defaults/main.yml for more configuration options
+
+# containerd_storage_dir: "/var/lib/containerd"
+# containerd_state_dir: "/run/containerd"
+# containerd_oom_score: 0
+
+# containerd_default_runtime: "runc"
+# containerd_snapshotter: "native"
+
+# containerd_runc_runtime:
+#   name: runc
+#   type: "io.containerd.runc.v2"
+#   engine: ""
+#   root: ""
+
+# containerd_additional_runtimes:
+# Example for Kata Containers as additional runtime:
+#   - name: kata
+#     type: "io.containerd.kata.v2"
+#     engine: ""
+#     root: ""
+
+# containerd_grpc_max_recv_message_size: 16777216
+# containerd_grpc_max_send_message_size: 16777216
+
+# containerd_debug_level: "info"
+
+# containerd_metrics_address: ""
+
+# containerd_metrics_grpc_histogram: false
+
+# Registries defined within containerd.
+# containerd_registries_mirrors:
+#  - prefix: docker.io
+#    mirrors:
+#     - host: https://registry-1.docker.io
+#       capabilities: ["pull", "resolve"]
+#       skip_verify: false
+
+# containerd_max_container_log_line_size: -1
+
+# containerd_registry_auth:
+#   - registry: 10.0.0.2:5000
+#     username: user
+#     password: pass

--- a/kubernetes-prod/inventory/sample/group_vars/all/coreos.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/coreos.yml
@@ -1,0 +1,2 @@
+## Does coreos need auto upgrade, default is true
+# coreos_auto_upgrade: true

--- a/kubernetes-prod/inventory/sample/group_vars/all/cri-o.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/cri-o.yml
@@ -1,0 +1,9 @@
+# Registries defined within cri-o.
+# crio_insecure_registries:
+#   - 10.0.0.2:5000
+
+# Auth config for the registries
+# crio_registry_auth:
+#   - registry: 10.0.0.2:5000
+#     username: user
+#     password: pass

--- a/kubernetes-prod/inventory/sample/group_vars/all/docker.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/docker.yml
@@ -1,0 +1,59 @@
+---
+## Uncomment this if you want to force overlay/overlay2 as docker storage driver
+## Please note that overlay2 is only supported on newer kernels
+# docker_storage_options: -s overlay2
+
+## Enable docker_container_storage_setup, it will configure devicemapper driver on Centos7 or RedHat7.
+docker_container_storage_setup: false
+
+## It must be define a disk path for docker_container_storage_setup_devs.
+## Otherwise docker-storage-setup will be executed incorrectly.
+# docker_container_storage_setup_devs: /dev/vdb
+
+## Uncomment this if you want to change the Docker Cgroup driver (native.cgroupdriver)
+## Valid options are systemd or cgroupfs, default is systemd
+# docker_cgroup_driver: systemd
+
+## Only set this if you have more than 3 nameservers:
+## If true Kubespray will only use the first 3, otherwise it will fail
+docker_dns_servers_strict: false
+
+# Path used to store Docker data
+docker_daemon_graph: "/var/lib/docker"
+
+## Used to set docker daemon iptables options to true
+docker_iptables_enabled: "false"
+
+# Docker log options
+# Rotate container stderr/stdout logs at 50m and keep last 5
+docker_log_opts: "--log-opt max-size=50m --log-opt max-file=5"
+
+# define docker bin_dir
+docker_bin_dir: "/usr/bin"
+
+# keep docker packages after installation; speeds up repeated ansible provisioning runs when '1'
+# kubespray deletes the docker package on each run, so caching the package makes sense
+docker_rpm_keepcache: 1
+
+## An obvious use case is allowing insecure-registry access to self hosted registries.
+## Can be ipaddress and domain_name.
+## example define 172.19.16.11 or mirror.registry.io
+# docker_insecure_registries:
+#   - mirror.registry.io
+#   - 172.19.16.11
+
+## Add other registry,example China registry mirror.
+# docker_registry_mirrors:
+#   - https://registry.docker-cn.com
+#   - https://mirror.aliyuncs.com
+
+## If non-empty will override default system MountFlags value.
+## This option takes a mount propagation flag: shared, slave
+## or private, which control whether mounts in the file system
+## namespace set up for docker will receive or propagate mounts
+## and unmounts. Leave empty for system default
+# docker_mount_flags:
+
+## A string of extra options to pass to the docker daemon.
+## This string should be exactly as you wish it to appear.
+# docker_options: ""

--- a/kubernetes-prod/inventory/sample/group_vars/all/etcd.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/etcd.yml
@@ -1,0 +1,16 @@
+---
+## Directory where etcd data stored
+etcd_data_dir: /var/lib/etcd
+
+## Container runtime
+## docker for docker, crio for cri-o and containerd for containerd.
+## Additionally you can set this to kubeadm if you want to install etcd using kubeadm
+## Kubeadm etcd deployment is experimental and only available for new deployments
+## If this is not set, container manager will be inherited from the Kubespray defaults
+## and not from k8s_cluster/k8s-cluster.yml, which might not be what you want.
+## Also this makes possible to use different container manager for etcd nodes.
+# container_manager: containerd
+
+## Settings for etcd deployment type
+# Set this to docker if you are using container_manager: docker
+etcd_deployment_type: host

--- a/kubernetes-prod/inventory/sample/group_vars/all/gcp.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/gcp.yml
@@ -1,0 +1,10 @@
+## GCP compute Persistent Disk CSI Driver credentials and parameters
+## See docs/gcp-pd-csi.md for information about the implementation
+
+## Specify the path to the file containing the service account credentials
+# gcp_pd_csi_sa_cred_file: "/my/safe/credentials/directory/cloud-sa.json"
+
+## To enable GCP Persistent Disk CSI driver, uncomment below
+# gcp_pd_csi_enabled: true
+# gcp_pd_csi_controller_replicas: 1
+# gcp_pd_csi_driver_image_tag: "v0.7.0-gke.0"

--- a/kubernetes-prod/inventory/sample/group_vars/all/hcloud.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/hcloud.yml
@@ -1,0 +1,22 @@
+## Values for the external Hcloud Cloud Controller
+# external_hcloud_cloud:
+#   hcloud_api_token: ""
+#   token_secret_name: hcloud
+#   with_networks: false # Use the hcloud controller-manager with networks support https://github.com/hetznercloud/hcloud-cloud-controller-manager#networks-support
+#   network_name: # network name/ID: If you manage the network yourself it might still be required to let the CCM know about private networks
+#   service_account_name: cloud-controller-manager
+#
+#   controller_image_tag: "latest"
+#   ## A dictionary of extra arguments to add to the openstack cloud controller manager daemonset
+#   ## Format:
+#   ##  external_hcloud_cloud.controller_extra_args:
+#   ##    arg1: "value1"
+#   ##    arg2: "value2"
+#   controller_extra_args: {}
+#
+#   load_balancers_location: # mutually exclusive with load_balancers_network_zone
+#   load_balancers_network_zone:
+#   load_balancers_disable_private_ingress: # set to true if using IPVS based plugins https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/docs/load_balancers.md#sample-service-with-networks
+#   load_balancers_use_private_ip: # set to true if using private networks
+#   load_balancers_enabled:
+#   network_routes_enabled:

--- a/kubernetes-prod/inventory/sample/group_vars/all/huaweicloud.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/huaweicloud.yml
@@ -1,0 +1,17 @@
+## Values for the external Huawei Cloud Controller
+# external_huaweicloud_lbaas_subnet_id: "Neutron subnet ID to create LBaaS VIP"
+# external_huaweicloud_lbaas_network_id: "Neutron network ID to create LBaaS VIP"
+
+## Credentials to authenticate against Keystone API
+## All of them are required Per default these values will be
+## read from the environment.
+# external_huaweicloud_auth_url: "{{ lookup('env','OS_AUTH_URL')  }}"
+# external_huaweicloud_access_key: "{{ lookup('env','OS_ACCESS_KEY')  }}"
+# external_huaweicloud_secret_key: "{{ lookup('env','OS_SECRET_KEY')  }}"
+# external_huaweicloud_region: "{{ lookup('env','OS_REGION_NAME')  }}"
+# external_huaweicloud_project_id: "{{ lookup('env','OS_TENANT_ID')| default(lookup('env','OS_PROJECT_ID'),true) }}"
+# external_huaweicloud_cloud: "{{ lookup('env','OS_CLOUD') }}"
+
+## The repo and tag of the external Huawei Cloud Controller image
+# external_huawei_cloud_controller_image_repo: "swr.ap-southeast-1.myhuaweicloud.com"
+# external_huawei_cloud_controller_image_tag: "v0.26.6"

--- a/kubernetes-prod/inventory/sample/group_vars/all/oci.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/oci.yml
@@ -1,0 +1,28 @@
+## When Oracle Cloud Infrastructure is used, set these variables
+# oci_private_key:
+# oci_region_id:
+# oci_tenancy_id:
+# oci_user_id:
+# oci_user_fingerprint:
+# oci_compartment_id:
+# oci_vnc_id:
+# oci_subnet1_id:
+# oci_subnet2_id:
+## Override these default/optional behaviors if you wish
+# oci_security_list_management: All
+## If you would like the controller to manage specific lists per subnet. This is a mapping of subnet ocids to security list ocids. Below are examples.
+# oci_security_lists:
+#   ocid1.subnet.oc1.phx.aaaaaaaasa53hlkzk6nzksqfccegk2qnkxmphkblst3riclzs4rhwg7rg57q: ocid1.securitylist.oc1.iad.aaaaaaaaqti5jsfvyw6ejahh7r4okb2xbtuiuguswhs746mtahn72r7adt7q
+#   ocid1.subnet.oc1.phx.aaaaaaaahuxrgvs65iwdz7ekwgg3l5gyah7ww5klkwjcso74u3e4i64hvtvq: ocid1.securitylist.oc1.iad.aaaaaaaaqti5jsfvyw6ejahh7r4okb2xbtuiuguswhs746mtahn72r7adt7q
+## If oci_use_instance_principals is true, you do not need to set the region, tenancy, user, key, passphrase, or fingerprint
+# oci_use_instance_principals: false
+# oci_cloud_controller_version: 0.6.0
+## If you would like to control OCI query rate limits for the controller
+# oci_rate_limit:
+#   rate_limit_qps_read:
+#   rate_limit_qps_write:
+#   rate_limit_bucket_read:
+#   rate_limit_bucket_write:
+## Other optional variables
+# oci_cloud_controller_pull_source: (default iad.ocir.io/oracle/cloud-provider-oci)
+# oci_cloud_controller_pull_secret: (name of pull secret to use if you define your own mirror above)

--- a/kubernetes-prod/inventory/sample/group_vars/all/offline.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/offline.yml
@@ -1,0 +1,106 @@
+---
+## Global Offline settings
+### Private Container Image Registry
+# registry_host: "myprivateregisry.com"
+# files_repo: "http://myprivatehttpd"
+### If using CentOS, RedHat, AlmaLinux or Fedora
+# yum_repo: "http://myinternalyumrepo"
+### If using Debian
+# debian_repo: "http://myinternaldebianrepo"
+### If using Ubuntu
+# ubuntu_repo: "http://myinternalubunturepo"
+
+## Container Registry overrides
+# kube_image_repo: "{{ registry_host }}"
+# gcr_image_repo: "{{ registry_host }}"
+# github_image_repo: "{{ registry_host }}"
+# docker_image_repo: "{{ registry_host }}"
+# quay_image_repo: "{{ registry_host }}"
+
+## Kubernetes components
+# kubeadm_download_url: "{{ files_repo }}/dl.k8s.io/release/{{ kubeadm_version }}/bin/linux/{{ image_arch }}/kubeadm"
+# kubectl_download_url: "{{ files_repo }}/dl.k8s.io/release/{{ kube_version }}/bin/linux/{{ image_arch }}/kubectl"
+# kubelet_download_url: "{{ files_repo }}/dl.k8s.io/release/{{ kube_version }}/bin/linux/{{ image_arch }}/kubelet"
+
+## CNI Plugins
+# cni_download_url: "{{ files_repo }}/github.com/containernetworking/plugins/releases/download/{{ cni_version }}/cni-plugins-linux-{{ image_arch }}-{{ cni_version }}.tgz"
+
+## cri-tools
+# crictl_download_url: "{{ files_repo }}/github.com/kubernetes-sigs/cri-tools/releases/download/{{ crictl_version }}/crictl-{{ crictl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
+
+## [Optional] etcd: only if you use etcd_deployment=host
+# etcd_download_url: "{{ files_repo }}/github.com/etcd-io/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-{{ image_arch }}.tar.gz"
+
+# [Optional] Calico: If using Calico network plugin
+# calicoctl_download_url: "{{ files_repo }}/github.com/projectcalico/calico/releases/download/{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
+# [Optional] Calico with kdd: If using Calico network plugin with kdd datastore
+# calico_crds_download_url: "{{ files_repo }}/github.com/projectcalico/calico/archive/{{ calico_version }}.tar.gz"
+
+# [Optional] Cilium: If using Cilium network plugin
+# ciliumcli_download_url: "{{ files_repo }}/github.com/cilium/cilium-cli/releases/download/{{ cilium_cli_version }}/cilium-linux-{{ image_arch }}.tar.gz"
+
+# [Optional] helm: only if you set helm_enabled: true
+# helm_download_url: "{{ files_repo }}/get.helm.sh/helm-{{ helm_version }}-linux-{{ image_arch }}.tar.gz"
+
+# [Optional] crun: only if you set crun_enabled: true
+# crun_download_url: "{{ files_repo }}/github.com/containers/crun/releases/download/{{ crun_version }}/crun-{{ crun_version }}-linux-{{ image_arch }}"
+
+# [Optional] kata: only if you set kata_containers_enabled: true
+# kata_containers_download_url: "{{ files_repo }}/github.com/kata-containers/kata-containers/releases/download/{{ kata_containers_version }}/kata-static-{{ kata_containers_version }}-{{ ansible_architecture }}.tar.xz"
+
+# [Optional] cri-dockerd: only if you set container_manager: docker
+# cri_dockerd_download_url: "{{ files_repo }}/github.com/Mirantis/cri-dockerd/releases/download/v{{ cri_dockerd_version }}/cri-dockerd-{{ cri_dockerd_version }}.{{ image_arch }}.tgz"
+
+# [Optional] runc: if you set container_manager to containerd or crio
+# runc_download_url: "{{ files_repo }}/github.com/opencontainers/runc/releases/download/{{ runc_version }}/runc.{{ image_arch }}"
+
+# [Optional] cri-o: only if you set container_manager: crio
+# crio_download_base: "download.opensuse.org/repositories/devel:kubic:libcontainers:stable"
+# crio_download_crio: "http://{{ crio_download_base }}:/cri-o:/"
+# crio_download_url: "{{ files_repo }}/storage.googleapis.com/cri-o/artifacts/cri-o.{{ image_arch }}.{{ crio_version }}.tar.gz"
+# skopeo_download_url: "{{ files_repo }}/github.com/lework/skopeo-binary/releases/download/{{ skopeo_version }}/skopeo-linux-{{ image_arch }}"
+
+# [Optional] containerd: only if you set container_runtime: containerd
+# containerd_download_url: "{{ files_repo }}/github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-{{ image_arch }}.tar.gz"
+# nerdctl_download_url: "{{ files_repo }}/github.com/containerd/nerdctl/releases/download/v{{ nerdctl_version }}/nerdctl-{{ nerdctl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
+
+# [Optional] runsc,containerd-shim-runsc: only if you set gvisor_enabled: true
+# gvisor_runsc_download_url: "{{ files_repo }}/storage.googleapis.com/gvisor/releases/release/{{ gvisor_version }}/{{ ansible_architecture }}/runsc"
+# gvisor_containerd_shim_runsc_download_url: "{{ files_repo }}/storage.googleapis.com/gvisor/releases/release/{{ gvisor_version }}/{{ ansible_architecture }}/containerd-shim-runsc-v1"
+
+# [Optional] Krew: only if you set krew_enabled: true
+# krew_download_url: "{{ files_repo }}/github.com/kubernetes-sigs/krew/releases/download/{{ krew_version }}/krew-{{ host_os }}_{{ image_arch }}.tar.gz"
+
+## CentOS/Redhat/AlmaLinux
+### For EL7, base and extras repo must be available, for EL8, baseos and appstream
+### By default we enable those repo automatically
+# rhel_enable_repos: false
+### Docker / Containerd
+# docker_rh_repo_base_url: "{{ yum_repo }}/docker-ce/$releasever/$basearch"
+# docker_rh_repo_gpgkey: "{{ yum_repo }}/docker-ce/gpg"
+
+## Fedora
+### Docker
+# docker_fedora_repo_base_url: "{{ yum_repo }}/docker-ce/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}"
+# docker_fedora_repo_gpgkey: "{{ yum_repo }}/docker-ce/gpg"
+### Containerd
+# containerd_fedora_repo_base_url: "{{ yum_repo }}/containerd"
+# containerd_fedora_repo_gpgkey: "{{ yum_repo }}/docker-ce/gpg"
+
+## Debian
+### Docker
+# docker_debian_repo_base_url: "{{ debian_repo }}/docker-ce"
+# docker_debian_repo_gpgkey: "{{ debian_repo }}/docker-ce/gpg"
+### Containerd
+# containerd_debian_repo_base_url: "{{ debian_repo }}/containerd"
+# containerd_debian_repo_gpgkey: "{{ debian_repo }}/containerd/gpg"
+# containerd_debian_repo_repokey: 'YOURREPOKEY'
+
+## Ubuntu
+### Docker
+# docker_ubuntu_repo_base_url: "{{ ubuntu_repo }}/docker-ce"
+# docker_ubuntu_repo_gpgkey: "{{ ubuntu_repo }}/docker-ce/gpg"
+### Containerd
+# containerd_ubuntu_repo_base_url: "{{ ubuntu_repo }}/containerd"
+# containerd_ubuntu_repo_gpgkey: "{{ ubuntu_repo }}/containerd/gpg"
+# containerd_ubuntu_repo_repokey: 'YOURREPOKEY'

--- a/kubernetes-prod/inventory/sample/group_vars/all/openstack.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/openstack.yml
@@ -1,0 +1,72 @@
+## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)
+# openstack_blockstorage_version: "v1/v2/auto (default)"
+# openstack_blockstorage_ignore_volume_az: yes
+## When OpenStack is used, if LBaaSv2 is available you can enable it with the following 2 variables.
+# openstack_lbaas_enabled: True
+# openstack_lbaas_subnet_id: "Neutron subnet ID (not network ID) to create LBaaS VIP"
+## To enable automatic floating ip provisioning, specify a subnet.
+# openstack_lbaas_floating_network_id: "Neutron network ID (not subnet ID) to get floating IP from, disabled by default"
+## Override default LBaaS behavior
+# openstack_lbaas_use_octavia: False
+# openstack_lbaas_method: "ROUND_ROBIN"
+# openstack_lbaas_provider: "haproxy"
+# openstack_lbaas_create_monitor: "yes"
+# openstack_lbaas_monitor_delay: "1m"
+# openstack_lbaas_monitor_timeout: "30s"
+# openstack_lbaas_monitor_max_retries: "3"
+
+## Values for the external OpenStack Cloud Controller
+# external_openstack_lbaas_enabled: true
+# external_openstack_lbaas_floating_network_id: "Neutron network ID to get floating IP from"
+# external_openstack_lbaas_floating_subnet_id: "Neutron subnet ID to get floating IP from"
+# external_openstack_lbaas_method: ROUND_ROBIN
+# external_openstack_lbaas_provider: amphora
+# external_openstack_lbaas_subnet_id: "Neutron subnet ID to create LBaaS VIP"
+# external_openstack_lbaas_network_id: "Neutron network ID to create LBaaS VIP"
+# external_openstack_lbaas_manage_security_groups: false
+# external_openstack_lbaas_create_monitor: false
+# external_openstack_lbaas_monitor_delay: 5
+# external_openstack_lbaas_monitor_max_retries: 1
+# external_openstack_lbaas_monitor_timeout: 3
+# external_openstack_lbaas_internal_lb: false
+# external_openstack_network_ipv6_disabled: false
+# external_openstack_network_internal_networks: []
+# external_openstack_network_public_networks: []
+# external_openstack_metadata_search_order: "configDrive,metadataService"
+
+## Application credentials to authenticate against Keystone API
+## Those settings will take precedence over username and password that might be set your environment
+## All of them are required
+# external_openstack_application_credential_name:
+# external_openstack_application_credential_id:
+# external_openstack_application_credential_secret:
+
+## The tag of the external OpenStack Cloud Controller image
+# external_openstack_cloud_controller_image_tag: "latest"
+
+## Tags for the Cinder CSI images
+## registry.k8s.io/sig-storage/csi-attacher
+# cinder_csi_attacher_image_tag: "v4.4.2"
+## registry.k8s.io/sig-storage/csi-provisioner
+# cinder_csi_provisioner_image_tag: "v3.6.2"
+## registry.k8s.io/sig-storage/csi-snapshotter
+# cinder_csi_snapshotter_image_tag: "v6.3.2"
+## registry.k8s.io/sig-storage/csi-resizer
+# cinder_csi_resizer_image_tag: "v1.9.2"
+## registry.k8s.io/sig-storage/livenessprobe
+# cinder_csi_livenessprobe_image_tag: "v2.11.0"
+
+## To use Cinder CSI plugin to provision volumes set this value to true
+## Make sure to source in the openstack credentials
+# cinder_csi_enabled: true
+# cinder_csi_controller_replicas: 1
+# storage_classes:
+#   - name: "cinder-csi"
+#     provisioner: "kubernetes.io/cinder"
+#     mount_options:
+#       - "discard"
+#     parameters:
+#       type: "thin"
+#       availability: "nova"
+#     reclaim_policy: "Delete"
+#     volume_binding_mode: "WaitForFirstConsumer"

--- a/kubernetes-prod/inventory/sample/group_vars/all/upcloud.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/upcloud.yml
@@ -1,0 +1,24 @@
+## Repo for UpClouds csi-driver: https://github.com/UpCloudLtd/upcloud-csi
+## To use UpClouds CSI plugin to provision volumes set this value to true
+## Remember to set UPCLOUD_USERNAME and UPCLOUD_PASSWORD
+# upcloud_csi_enabled: true
+# upcloud_csi_controller_replicas: 1
+## Override used image tags
+# upcloud_csi_provisioner_image_tag: "v3.1.0"
+# upcloud_csi_attacher_image_tag: "v3.4.0"
+# upcloud_csi_resizer_image_tag: "v1.4.0"
+# upcloud_csi_plugin_image_tag: "v0.3.3"
+# upcloud_csi_node_image_tag: "v2.5.0"
+# upcloud_tolerations: []
+## Storage class options
+# storage_classes:
+#   - name: standard
+#     is_default: true
+#     expand_persistent_volumes: true
+#     parameters:
+#       tier: maxiops
+#   - name: hdd
+#     is_default: false
+#     expand_persistent_volumes: true
+#     parameters:
+#       tier: hdd

--- a/kubernetes-prod/inventory/sample/group_vars/all/vsphere.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/all/vsphere.yml
@@ -1,0 +1,32 @@
+## Values for the external vSphere Cloud Provider
+# external_vsphere_vcenter_ip: "myvcenter.domain.com"
+# external_vsphere_vcenter_port: "443"
+# external_vsphere_insecure: "true"
+# external_vsphere_user: "administrator@vsphere.local" # Can also be set via the `VSPHERE_USER` environment variable
+# external_vsphere_password: "K8s_admin" # Can also be set via the `VSPHERE_PASSWORD` environment variable
+# external_vsphere_datacenter: "DATACENTER_name"
+# external_vsphere_kubernetes_cluster_id: "kubernetes-cluster-id"
+
+## Vsphere version where located VMs
+# external_vsphere_version: "6.7u3"
+
+## Tags for the external vSphere Cloud Provider images
+## gcr.io/cloud-provider-vsphere/cpi/release/manager
+# external_vsphere_cloud_controller_image_tag: "latest"
+## gcr.io/cloud-provider-vsphere/csi/release/syncer
+# vsphere_syncer_image_tag: "v2.5.1"
+## registry.k8s.io/sig-storage/csi-attacher
+# vsphere_csi_attacher_image_tag: "v3.4.0"
+## gcr.io/cloud-provider-vsphere/csi/release/driver
+# vsphere_csi_controller: "v2.5.1"
+## registry.k8s.io/sig-storage/livenessprobe
+# vsphere_csi_liveness_probe_image_tag: "v2.6.0"
+## registry.k8s.io/sig-storage/csi-provisioner
+# vsphere_csi_provisioner_image_tag: "v3.1.0"
+## registry.k8s.io/sig-storage/csi-resizer
+## makes sense only for vSphere version >=7.0
+# vsphere_csi_resizer_tag: "v1.3.0"
+
+## To use vSphere CSI plugin to provision volumes set this value to true
+# vsphere_csi_enabled: true
+# vsphere_csi_controller_replicas: 1

--- a/kubernetes-prod/inventory/sample/group_vars/etcd.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/etcd.yml
@@ -1,0 +1,35 @@
+---
+## Etcd auto compaction retention for mvcc key value store in hour
+# etcd_compaction_retention: 0
+
+## Set level of detail for etcd exported metrics, specify 'extensive' to include histogram metrics.
+# etcd_metrics: basic
+
+## Etcd is restricted by default to 512M on systems under 4GB RAM, 512MB is not enough for much more than testing.
+## Set this if your etcd nodes have less than 4GB but you want more RAM for etcd. Set to 0 for unrestricted RAM.
+## This value is only relevant when deploying etcd with `etcd_deployment_type: docker`
+# etcd_memory_limit: "512M"
+
+## Etcd has a default of 2G for its space quota. If you put a value in etcd_memory_limit which is less than
+## etcd_quota_backend_bytes, you may encounter out of memory terminations of the etcd cluster. Please check
+## etcd documentation for more information.
+# 8G is a suggested maximum size for normal environments and etcd warns at startup if the configured value exceeds it.
+# etcd_quota_backend_bytes: "2147483648"
+
+# Maximum client request size in bytes the server will accept.
+# etcd is designed to handle small key value pairs typical for metadata.
+# Larger requests will work, but may increase the latency of other requests
+# etcd_max_request_bytes: "1572864"
+
+### ETCD: disable peer client cert authentication.
+# This affects ETCD_PEER_CLIENT_CERT_AUTH variable
+# etcd_peer_client_auth: true
+
+## Enable distributed tracing
+## To enable this experimental feature, set the etcd_experimental_enable_distributed_tracing: true, along with the
+## etcd_experimental_distributed_tracing_sample_rate to choose how many samples to collect per million spans,
+## the default sampling rate is 0 https://etcd.io/docs/v3.5/op-guide/monitoring/#distributed-tracing
+# etcd_experimental_enable_distributed_tracing: false
+# etcd_experimental_distributed_tracing_sample_rate: 100
+# etcd_experimental_distributed_tracing_address: "localhost:4317"
+# etcd_experimental_distributed_tracing_service_name: etcd

--- a/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -1,0 +1,261 @@
+---
+# Kubernetes dashboard
+# RBAC required. see docs/getting-started.md for access details.
+# dashboard_enabled: false
+
+# Helm deployment
+helm_enabled: false
+
+# Registry deployment
+registry_enabled: false
+# registry_namespace: kube-system
+# registry_storage_class: ""
+# registry_disk_size: "10Gi"
+
+# Metrics Server deployment
+metrics_server_enabled: false
+# metrics_server_container_port: 10250
+# metrics_server_kubelet_insecure_tls: true
+# metrics_server_metric_resolution: 15s
+# metrics_server_kubelet_preferred_address_types: "InternalIP,ExternalIP,Hostname"
+# metrics_server_host_network: false
+# metrics_server_replicas: 1
+
+# Rancher Local Path Provisioner
+local_path_provisioner_enabled: false
+# local_path_provisioner_namespace: "local-path-storage"
+# local_path_provisioner_storage_class: "local-path"
+# local_path_provisioner_reclaim_policy: Delete
+# local_path_provisioner_claim_root: /opt/local-path-provisioner/
+# local_path_provisioner_debug: false
+# local_path_provisioner_image_repo: "rancher/local-path-provisioner"
+# local_path_provisioner_image_tag: "v0.0.24"
+# local_path_provisioner_helper_image_repo: "busybox"
+# local_path_provisioner_helper_image_tag: "latest"
+
+# Local volume provisioner deployment
+local_volume_provisioner_enabled: false
+# local_volume_provisioner_namespace: kube-system
+# local_volume_provisioner_nodelabels:
+#   - kubernetes.io/hostname
+#   - topology.kubernetes.io/region
+#   - topology.kubernetes.io/zone
+# local_volume_provisioner_storage_classes:
+#   local-storage:
+#     host_dir: /mnt/disks
+#     mount_dir: /mnt/disks
+#     volume_mode: Filesystem
+#     fs_type: ext4
+#   fast-disks:
+#     host_dir: /mnt/fast-disks
+#     mount_dir: /mnt/fast-disks
+#     block_cleaner_command:
+#       - "/scripts/shred.sh"
+#       - "2"
+#     volume_mode: Filesystem
+#     fs_type: ext4
+# local_volume_provisioner_tolerations:
+#   - effect: NoSchedule
+#     operator: Exists
+
+# CSI Volume Snapshot Controller deployment, set this to true if your CSI is able to manage snapshots
+# currently, setting cinder_csi_enabled=true would automatically enable the snapshot controller
+# Longhorn is an external CSI that would also require setting this to true but it is not included in kubespray
+# csi_snapshot_controller_enabled: false
+# csi snapshot namespace
+# snapshot_controller_namespace: kube-system
+
+# CephFS provisioner deployment
+cephfs_provisioner_enabled: false
+# cephfs_provisioner_namespace: "cephfs-provisioner"
+# cephfs_provisioner_cluster: ceph
+# cephfs_provisioner_monitors: "172.24.0.1:6789,172.24.0.2:6789,172.24.0.3:6789"
+# cephfs_provisioner_admin_id: admin
+# cephfs_provisioner_secret: secret
+# cephfs_provisioner_storage_class: cephfs
+# cephfs_provisioner_reclaim_policy: Delete
+# cephfs_provisioner_claim_root: /volumes
+# cephfs_provisioner_deterministic_names: true
+
+# RBD provisioner deployment
+rbd_provisioner_enabled: false
+# rbd_provisioner_namespace: rbd-provisioner
+# rbd_provisioner_replicas: 2
+# rbd_provisioner_monitors: "172.24.0.1:6789,172.24.0.2:6789,172.24.0.3:6789"
+# rbd_provisioner_pool: kube
+# rbd_provisioner_admin_id: admin
+# rbd_provisioner_secret_name: ceph-secret-admin
+# rbd_provisioner_secret: ceph-key-admin
+# rbd_provisioner_user_id: kube
+# rbd_provisioner_user_secret_name: ceph-secret-user
+# rbd_provisioner_user_secret: ceph-key-user
+# rbd_provisioner_user_secret_namespace: rbd-provisioner
+# rbd_provisioner_fs_type: ext4
+# rbd_provisioner_image_format: "2"
+# rbd_provisioner_image_features: layering
+# rbd_provisioner_storage_class: rbd
+# rbd_provisioner_reclaim_policy: Delete
+
+# Nginx ingress controller deployment
+ingress_nginx_enabled: false
+# ingress_nginx_host_network: false
+# ingress_nginx_service_type: LoadBalancer
+ingress_publish_status_address: ""
+# ingress_nginx_nodeselector:
+#   kubernetes.io/os: "linux"
+# ingress_nginx_tolerations:
+#   - key: "node-role.kubernetes.io/control-plane"
+#     operator: "Equal"
+#     value: ""
+#     effect: "NoSchedule"
+# ingress_nginx_namespace: "ingress-nginx"
+# ingress_nginx_insecure_port: 80
+# ingress_nginx_secure_port: 443
+# ingress_nginx_configmap:
+#   map-hash-bucket-size: "128"
+#   ssl-protocols: "TLSv1.2 TLSv1.3"
+# ingress_nginx_configmap_tcp_services:
+#   9000: "default/example-go:8080"
+# ingress_nginx_configmap_udp_services:
+#   53: "kube-system/coredns:53"
+# ingress_nginx_extra_args:
+#   - --default-ssl-certificate=default/foo-tls
+# ingress_nginx_termination_grace_period_seconds: 300
+# ingress_nginx_class: nginx
+# ingress_nginx_without_class: true
+# ingress_nginx_default: false
+
+# ALB ingress controller deployment
+ingress_alb_enabled: false
+# alb_ingress_aws_region: "us-east-1"
+# alb_ingress_restrict_scheme: "false"
+# Enables logging on all outbound requests sent to the AWS API.
+# If logging is desired, set to true.
+# alb_ingress_aws_debug: "false"
+
+# Cert manager deployment
+cert_manager_enabled: false
+# cert_manager_namespace: "cert-manager"
+# cert_manager_tolerations:
+#   - key: node-role.kubernetes.io/control-plane
+#     effect: NoSchedule
+# cert_manager_affinity:
+#  nodeAffinity:
+#    preferredDuringSchedulingIgnoredDuringExecution:
+#    - weight: 100
+#      preference:
+#        matchExpressions:
+#        - key: node-role.kubernetes.io/control-plane
+#          operator: In
+#          values:
+#          - ""
+# cert_manager_nodeselector:
+#   kubernetes.io/os: "linux"
+
+# cert_manager_trusted_internal_ca: |
+#   -----BEGIN CERTIFICATE-----
+#   [REPLACE with your CA certificate]
+#   -----END CERTIFICATE-----
+# cert_manager_leader_election_namespace: kube-system
+
+# cert_manager_dns_policy: "ClusterFirst"
+# cert_manager_dns_config:
+#   nameservers:
+#     - "1.1.1.1"
+#     - "8.8.8.8"
+
+# cert_manager_controller_extra_args:
+#   - "--dns01-recursive-nameservers-only=true"
+#   - "--dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53"
+
+# MetalLB deployment
+metallb_enabled: false
+metallb_speaker_enabled: "{{ metallb_enabled }}"
+# metallb_version: v0.13.9
+# metallb_protocol: "layer2"
+# metallb_port: "7472"
+# metallb_memberlist_port: "7946"
+# metallb_config:
+#   speaker:
+#     nodeselector:
+#       kubernetes.io/os: "linux"
+#     tolerations:
+#       - key: "node-role.kubernetes.io/control-plane"
+#         operator: "Equal"
+#         value: ""
+#         effect: "NoSchedule"
+#   controller:
+#     nodeselector:
+#       kubernetes.io/os: "linux"
+#     tolerations:
+#       - key: "node-role.kubernetes.io/control-plane"
+#         operator: "Equal"
+#         value: ""
+#         effect: "NoSchedule"
+#   address_pools:
+#     primary:
+#       ip_range:
+#         - 10.5.0.0/16
+#       auto_assign: true
+#     pool1:
+#       ip_range:
+#         - 10.6.0.0/16
+#       auto_assign: true
+#     pool2:
+#       ip_range:
+#         - 10.10.0.0/16
+#       auto_assign: true
+#   layer2:
+#     - primary
+#   layer3:
+#     defaults:
+#       peer_port: 179
+#       hold_time: 120s
+#     communities:
+#       vpn-only: "1234:1"
+#       NO_ADVERTISE: "65535:65282"
+#     metallb_peers:
+#         peer1:
+#           peer_address: 10.6.0.1
+#           peer_asn: 64512
+#           my_asn: 4200000000
+#           communities:
+#             - vpn-only
+#           address_pool:
+#             - pool1
+#         peer2:
+#           peer_address: 10.10.0.1
+#           peer_asn: 64513
+#           my_asn: 4200000000
+#           communities:
+#             - NO_ADVERTISE
+#           address_pool:
+#             - pool2
+
+argocd_enabled: false
+# argocd_version: v2.8.4
+# argocd_namespace: argocd
+# Default password:
+#   - https://argo-cd.readthedocs.io/en/stable/getting_started/#4-login-using-the-cli
+#   ---
+#   The initial password is autogenerated and stored in `argocd-initial-admin-secret` in the argocd namespace defined above.
+#   Using the argocd CLI the generated password can be automatically be fetched from the current kubectl context with the command:
+#   argocd admin initial-password -n argocd
+#   ---
+# Use the following var to set admin password
+# argocd_admin_password: "password"
+
+# The plugin manager for kubectl
+krew_enabled: false
+krew_root_dir: "/usr/local/krew"
+
+# Kube VIP
+kube_vip_enabled: false
+# kube_vip_arp_enabled: true
+# kube_vip_controlplane_enabled: true
+# kube_vip_address: 192.168.56.120
+# loadbalancer_apiserver:
+#   address: "{{ kube_vip_address }}"
+#   port: 6443
+# kube_vip_interface: eth0
+# kube_vip_services_enabled: false

--- a/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -1,0 +1,373 @@
+---
+# Kubernetes configuration dirs and system namespace.
+# Those are where all the additional config stuff goes
+# the kubernetes normally puts in /srv/kubernetes.
+# This puts them in a sane location and namespace.
+# Editing those values will almost surely break something.
+kube_config_dir: /etc/kubernetes
+kube_script_dir: "{{ bin_dir }}/kubernetes-scripts"
+kube_manifest_dir: "{{ kube_config_dir }}/manifests"
+
+# This is where all the cert scripts and certs will be located
+kube_cert_dir: "{{ kube_config_dir }}/ssl"
+
+# This is where all of the bearer tokens will be stored
+kube_token_dir: "{{ kube_config_dir }}/tokens"
+
+kube_api_anonymous_auth: true
+
+## Change this to use another Kubernetes version, e.g. a current beta release
+kube_version: v1.29.2
+
+# Where the binaries will be downloaded.
+# Note: ensure that you've enough disk space (about 1G)
+local_release_dir: "/tmp/releases"
+# Random shifts for retrying failed ops like pushing/downloading
+retry_stagger: 5
+
+# This is the user that owns tha cluster installation.
+kube_owner: kube
+
+# This is the group that the cert creation scripts chgrp the
+# cert files to. Not really changeable...
+kube_cert_group: kube-cert
+
+# Cluster Loglevel configuration
+kube_log_level: 2
+
+# Directory where credentials will be stored
+credentials_dir: "{{ inventory_dir }}/credentials"
+
+## It is possible to activate / deactivate selected authentication methods (oidc, static token auth)
+# kube_oidc_auth: false
+# kube_token_auth: false
+
+
+## Variables for OpenID Connect Configuration https://kubernetes.io/docs/admin/authentication/
+## To use OpenID you have to deploy additional an OpenID Provider (e.g Dex, Keycloak, ...)
+
+# kube_oidc_url: https:// ...
+# kube_oidc_client_id: kubernetes
+## Optional settings for OIDC
+# kube_oidc_ca_file: "{{ kube_cert_dir }}/ca.pem"
+# kube_oidc_username_claim: sub
+# kube_oidc_username_prefix: 'oidc:'
+# kube_oidc_groups_claim: groups
+# kube_oidc_groups_prefix: 'oidc:'
+
+## Variables to control webhook authn/authz
+# kube_webhook_token_auth: false
+# kube_webhook_token_auth_url: https://...
+# kube_webhook_token_auth_url_skip_tls_verify: false
+
+## For webhook authorization, authorization_modes must include Webhook
+# kube_webhook_authorization: false
+# kube_webhook_authorization_url: https://...
+# kube_webhook_authorization_url_skip_tls_verify: false
+
+# Choose network plugin (cilium, calico, kube-ovn, weave or flannel. Use cni for generic cni plugin)
+# Can also be set to 'cloud', which lets the cloud provider setup appropriate routing
+kube_network_plugin: calico
+
+# Setting multi_networking to true will install Multus: https://github.com/k8snetworkplumbingwg/multus-cni
+kube_network_plugin_multus: false
+
+# Kubernetes internal network for services, unused block of space.
+kube_service_addresses: 10.233.0.0/18
+
+# internal network. When used, it will assign IP
+# addresses from this range to individual pods.
+# This network must be unused in your network infrastructure!
+kube_pods_subnet: 10.233.64.0/18
+
+# internal network node size allocation (optional). This is the size allocated
+# to each node for pod IP address allocation. Note that the number of pods per node is
+# also limited by the kubelet_max_pods variable which defaults to 110.
+#
+# Example:
+# Up to 64 nodes and up to 254 or kubelet_max_pods (the lowest of the two) pods per node:
+#  - kube_pods_subnet: 10.233.64.0/18
+#  - kube_network_node_prefix: 24
+#  - kubelet_max_pods: 110
+#
+# Example:
+# Up to 128 nodes and up to 126 or kubelet_max_pods (the lowest of the two) pods per node:
+#  - kube_pods_subnet: 10.233.64.0/18
+#  - kube_network_node_prefix: 25
+#  - kubelet_max_pods: 110
+kube_network_node_prefix: 24
+
+# Configure Dual Stack networking (i.e. both IPv4 and IPv6)
+enable_dual_stack_networks: false
+
+# Kubernetes internal network for IPv6 services, unused block of space.
+# This is only used if enable_dual_stack_networks is set to true
+# This provides 4096 IPv6 IPs
+kube_service_addresses_ipv6: fd85:ee78:d8a6:8607::1000/116
+
+# Internal network. When used, it will assign IPv6 addresses from this range to individual pods.
+# This network must not already be in your network infrastructure!
+# This is only used if enable_dual_stack_networks is set to true.
+# This provides room for 256 nodes with 254 pods per node.
+kube_pods_subnet_ipv6: fd85:ee78:d8a6:8607::1:0000/112
+
+# IPv6 subnet size allocated to each for pods.
+# This is only used if enable_dual_stack_networks is set to true
+# This provides room for 254 pods per node.
+kube_network_node_prefix_ipv6: 120
+
+# The port the API Server will be listening on.
+kube_apiserver_ip: "{{ kube_service_addresses | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(1) | ansible.utils.ipaddr('address') }}"
+kube_apiserver_port: 6443  # (https)
+
+# Kube-proxy proxyMode configuration.
+# Can be ipvs, iptables
+kube_proxy_mode: ipvs
+
+# configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface
+# must be set to true for MetalLB, kube-vip(ARP enabled) to work
+kube_proxy_strict_arp: false
+
+# A string slice of values which specify the addresses to use for NodePorts.
+# Values may be valid IP blocks (e.g. 1.2.3.0/24, 1.2.3.4/32).
+# The default empty string slice ([]) means to use all local addresses.
+# kube_proxy_nodeport_addresses_cidr is retained for legacy config
+kube_proxy_nodeport_addresses: >-
+  {%- if kube_proxy_nodeport_addresses_cidr is defined -%}
+  [{{ kube_proxy_nodeport_addresses_cidr }}]
+  {%- else -%}
+  []
+  {%- endif -%}
+
+# If non-empty, will use this string as identification instead of the actual hostname
+# kube_override_hostname: >-
+#   {%- if cloud_provider is defined and cloud_provider in ['aws'] -%}
+#   {%- else -%}
+#   {{ inventory_hostname }}
+#   {%- endif -%}
+
+## Encrypting Secret Data at Rest
+kube_encrypt_secret_data: false
+
+# Graceful Node Shutdown (Kubernetes >= 1.21.0), see https://kubernetes.io/blog/2021/04/21/graceful-node-shutdown-beta/
+# kubelet_shutdown_grace_period had to be greater than kubelet_shutdown_grace_period_critical_pods to allow
+# non-critical podsa to also terminate gracefully
+# kubelet_shutdown_grace_period: 60s
+# kubelet_shutdown_grace_period_critical_pods: 20s
+
+# DNS configuration.
+# Kubernetes cluster name, also will be used as DNS domain
+cluster_name: cluster.local
+# Subdomains of DNS domain to be resolved via /etc/resolv.conf for hostnet pods
+ndots: 2
+# dns_timeout: 2
+# dns_attempts: 2
+# Custom search domains to be added in addition to the default cluster search domains
+# searchdomains:
+#   - svc.{{ cluster_name }}
+#   - default.svc.{{ cluster_name }}
+# Remove default cluster search domains (``default.svc.{{ dns_domain }}, svc.{{ dns_domain }}``).
+# remove_default_searchdomains: false
+# Can be coredns, coredns_dual, manual or none
+dns_mode: coredns
+# Set manual server if using a custom cluster DNS server
+# manual_dns_server: 10.x.x.x
+# Enable nodelocal dns cache
+enable_nodelocaldns: true
+enable_nodelocaldns_secondary: false
+nodelocaldns_ip: 169.254.25.10
+nodelocaldns_health_port: 9254
+nodelocaldns_second_health_port: 9256
+nodelocaldns_bind_metrics_host_ip: false
+nodelocaldns_secondary_skew_seconds: 5
+# nodelocaldns_external_zones:
+# - zones:
+#   - example.com
+#   - example.io:1053
+#   nameservers:
+#   - 1.1.1.1
+#   - 2.2.2.2
+#   cache: 5
+# - zones:
+#   - https://mycompany.local:4453
+#   nameservers:
+#   - 192.168.0.53
+#   cache: 0
+# - zones:
+#   - mydomain.tld
+#   nameservers:
+#   - 10.233.0.3
+#   cache: 5
+#   rewrite:
+#   - name website.tld website.namespace.svc.cluster.local
+# Enable k8s_external plugin for CoreDNS
+enable_coredns_k8s_external: false
+coredns_k8s_external_zone: k8s_external.local
+# Enable endpoint_pod_names option for kubernetes plugin
+enable_coredns_k8s_endpoint_pod_names: false
+# Set forward options for upstream DNS servers in coredns (and nodelocaldns) config
+# dns_upstream_forward_extra_opts:
+#   policy: sequential
+# Apply extra options to coredns kubernetes plugin
+# coredns_kubernetes_extra_opts:
+#   - 'fallthrough example.local'
+# Forward extra domains to the coredns kubernetes plugin
+# coredns_kubernetes_extra_domains: ''
+
+# Can be docker_dns, host_resolvconf or none
+resolvconf_mode: host_resolvconf
+# Deploy netchecker app to verify DNS resolve as an HTTP service
+deploy_netchecker: false
+# Ip address of the kubernetes skydns service
+skydns_server: "{{ kube_service_addresses | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(3) | ansible.utils.ipaddr('address') }}"
+skydns_server_secondary: "{{ kube_service_addresses | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(4) | ansible.utils.ipaddr('address') }}"
+dns_domain: "{{ cluster_name }}"
+
+## Container runtime
+## docker for docker, crio for cri-o and containerd for containerd.
+## Default: containerd
+container_manager: containerd
+
+# Additional container runtimes
+kata_containers_enabled: false
+
+kubeadm_certificate_key: "{{ lookup('password', credentials_dir + '/kubeadm_certificate_key.creds length=64 chars=hexdigits') | lower }}"
+
+# K8s image pull policy (imagePullPolicy)
+k8s_image_pull_policy: IfNotPresent
+
+# audit log for kubernetes
+kubernetes_audit: false
+
+# define kubelet config dir for dynamic kubelet
+# kubelet_config_dir:
+default_kubelet_config_dir: "{{ kube_config_dir }}/dynamic_kubelet_dir"
+
+# Make a copy of kubeconfig on the host that runs Ansible in {{ inventory_dir }}/artifacts
+# kubeconfig_localhost: false
+# Use ansible_host as external api ip when copying over kubeconfig.
+# kubeconfig_localhost_ansible_host: false
+# Download kubectl onto the host that runs Ansible in {{ bin_dir }}
+# kubectl_localhost: false
+
+# A comma separated list of levels of node allocatable enforcement to be enforced by kubelet.
+# Acceptable options are 'pods', 'system-reserved', 'kube-reserved' and ''. Default is "".
+# kubelet_enforce_node_allocatable: pods
+
+## Set runtime and kubelet cgroups when using systemd as cgroup driver (default)
+# kubelet_runtime_cgroups: "/{{ kube_service_cgroups }}/{{ container_manager }}.service"
+# kubelet_kubelet_cgroups: "/{{ kube_service_cgroups }}/kubelet.service"
+
+## Set runtime and kubelet cgroups when using cgroupfs as cgroup driver
+# kubelet_runtime_cgroups_cgroupfs: "/system.slice/{{ container_manager }}.service"
+# kubelet_kubelet_cgroups_cgroupfs: "/system.slice/kubelet.service"
+
+# Optionally reserve this space for kube daemons.
+# kube_reserved: false
+## Uncomment to override default values
+## The following two items need to be set when kube_reserved is true
+# kube_reserved_cgroups_for_service_slice: kube.slice
+# kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"
+# kube_memory_reserved: 256Mi
+# kube_cpu_reserved: 100m
+# kube_ephemeral_storage_reserved: 2Gi
+# kube_pid_reserved: "1000"
+# Reservation for master hosts
+# kube_master_memory_reserved: 512Mi
+# kube_master_cpu_reserved: 200m
+# kube_master_ephemeral_storage_reserved: 2Gi
+# kube_master_pid_reserved: "1000"
+
+## Optionally reserve resources for OS system daemons.
+# system_reserved: true
+## Uncomment to override default values
+## The following two items need to be set when system_reserved is true
+# system_reserved_cgroups_for_service_slice: system.slice
+# system_reserved_cgroups: "/{{ system_reserved_cgroups_for_service_slice }}"
+# system_memory_reserved: 512Mi
+# system_cpu_reserved: 500m
+# system_ephemeral_storage_reserved: 2Gi
+## Reservation for master hosts
+# system_master_memory_reserved: 256Mi
+# system_master_cpu_reserved: 250m
+# system_master_ephemeral_storage_reserved: 2Gi
+
+## Eviction Thresholds to avoid system OOMs
+# https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#eviction-thresholds
+# eviction_hard: {}
+# eviction_hard_control_plane: {}
+
+# An alternative flexvolume plugin directory
+# kubelet_flexvolumes_plugins_dir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+
+## Supplementary addresses that can be added in kubernetes ssl keys.
+## That can be useful for example to setup a keepalived virtual IP
+# supplementary_addresses_in_ssl_keys: [10.0.0.1, 10.0.0.2, 10.0.0.3]
+
+## Running on top of openstack vms with cinder enabled may lead to unschedulable pods due to NoVolumeZoneConflict restriction in kube-scheduler.
+## See https://github.com/kubernetes-sigs/kubespray/issues/2141
+## Set this variable to true to get rid of this issue
+volume_cross_zone_attachment: false
+## Add Persistent Volumes Storage Class for corresponding cloud provider (supported: in-tree OpenStack, Cinder CSI,
+## AWS EBS CSI, Azure Disk CSI, GCP Persistent Disk CSI)
+persistent_volumes_enabled: false
+
+## Container Engine Acceleration
+## Enable container acceleration feature, for example use gpu acceleration in containers
+# nvidia_accelerator_enabled: true
+## Nvidia GPU driver install. Install will by done by a (init) pod running as a daemonset.
+## Important: if you use Ubuntu then you should set in all.yml 'docker_storage_options: -s overlay2'
+## Array with nvida_gpu_nodes, leave empty or comment if you don't want to install drivers.
+## Labels and taints won't be set to nodes if they are not in the array.
+# nvidia_gpu_nodes:
+#   - kube-gpu-001
+# nvidia_driver_version: "384.111"
+## flavor can be tesla or gtx
+# nvidia_gpu_flavor: gtx
+## NVIDIA driver installer images. Change them if you have trouble accessing gcr.io.
+# nvidia_driver_install_centos_container: atzedevries/nvidia-centos-driver-installer:2
+# nvidia_driver_install_ubuntu_container: gcr.io/google-containers/ubuntu-nvidia-driver-installer@sha256:7df76a0f0a17294e86f691c81de6bbb7c04a1b4b3d4ea4e7e2cccdc42e1f6d63
+## NVIDIA GPU device plugin image.
+# nvidia_gpu_device_plugin_container: "registry.k8s.io/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"
+
+## Support tls min version, Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+# tls_min_version: ""
+
+## Support tls cipher suites.
+# tls_cipher_suites: {}
+#   - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+#   - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+#   - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+#   - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+#   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+#   - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+#   - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+#   - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+#   - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+#   - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+#   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+#   - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+#   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+#   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+#   - TLS_ECDHE_RSA_WITH_RC4_128_SHA
+#   - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+#   - TLS_RSA_WITH_AES_128_CBC_SHA
+#   - TLS_RSA_WITH_AES_128_CBC_SHA256
+#   - TLS_RSA_WITH_AES_128_GCM_SHA256
+#   - TLS_RSA_WITH_AES_256_CBC_SHA
+#   - TLS_RSA_WITH_AES_256_GCM_SHA384
+#   - TLS_RSA_WITH_RC4_128_SHA
+
+## Amount of time to retain events. (default 1h0m0s)
+event_ttl_duration: "1h0m0s"
+
+## Automatically renew K8S control plane certificates on first Monday of each month
+auto_renew_certificates: false
+# First Monday of each month
+# auto_renew_certificates_systemd_calendar: "Mon *-*-1,2,3,4,5,6,7 03:{{ groups['kube_control_plane'].index(inventory_hostname) }}0:00"
+
+# kubeadm patches path
+kubeadm_patches:
+  enabled: false
+  source_dir: "{{ inventory_dir }}/patches"
+  dest_dir: "{{ kube_config_dir }}/patches"

--- a/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
@@ -1,0 +1,132 @@
+---
+# see roles/network_plugin/calico/defaults/main.yml
+
+# the default value of name
+calico_cni_name: k8s-pod-network
+
+## With calico it is possible to distributed routes with border routers of the datacenter.
+## Warning : enabling router peering will disable calico's default behavior ('node mesh').
+## The subnets of each nodes will be distributed by the datacenter router
+# peer_with_router: false
+
+# Enables Internet connectivity from containers
+# nat_outgoing: true
+# nat_outgoing_ipv6: false
+
+# Enables Calico CNI "host-local" IPAM plugin
+# calico_ipam_host_local: true
+
+# add default ippool name
+# calico_pool_name: "default-pool"
+
+# add default ippool blockSize (defaults kube_network_node_prefix)
+calico_pool_blocksize: 26
+
+# add default ippool CIDR (must be inside kube_pods_subnet, defaults to kube_pods_subnet otherwise)
+# calico_pool_cidr: 1.2.3.4/5
+
+# add default ippool CIDR to CNI config
+# calico_cni_pool: true
+
+# Add default IPV6 IPPool CIDR. Must be inside kube_pods_subnet_ipv6. Defaults to kube_pods_subnet_ipv6 if not set.
+# calico_pool_cidr_ipv6: fd85:ee78:d8a6:8607::1:0000/112
+
+# Add default IPV6 IPPool CIDR to CNI config
+# calico_cni_pool_ipv6: true
+
+# Global as_num (/calico/bgp/v1/global/as_num)
+# global_as_num: "64512"
+
+# If doing peering with node-assigned asn where the globas does not match your nodes, you want this
+# to be true.  All other cases, false.
+# calico_no_global_as_num: false
+
+# You can set MTU value here. If left undefined or empty, it will
+# not be specified in calico CNI config, so Calico will use built-in
+# defaults. The value should be a number, not a string.
+# calico_mtu: 1500
+
+# Configure the MTU to use for workload interfaces and tunnels.
+# - If Wireguard is enabled, subtract 60 from your network MTU (i.e 1500-60=1440)
+# - Otherwise, if VXLAN or BPF mode is enabled, subtract 50 from your network MTU (i.e. 1500-50=1450)
+# - Otherwise, if IPIP is enabled, subtract 20 from your network MTU (i.e. 1500-20=1480)
+# - Otherwise, if not using any encapsulation, set to your network MTU (i.e. 1500)
+# calico_veth_mtu: 1440
+
+# Advertise Cluster IPs
+# calico_advertise_cluster_ips: true
+
+# Advertise Service External IPs
+# calico_advertise_service_external_ips:
+# - x.x.x.x/24
+# - y.y.y.y/32
+
+# Advertise Service LoadBalancer IPs
+# calico_advertise_service_loadbalancer_ips:
+# - x.x.x.x/24
+# - y.y.y.y/16
+
+# Choose data store type for calico: "etcd" or "kdd" (kubernetes datastore)
+# calico_datastore: "kdd"
+
+# Choose Calico iptables backend: "Legacy", "Auto" or "NFT"
+# calico_iptables_backend: "Auto"
+
+# Use typha (only with kdd)
+# typha_enabled: false
+
+# Generate TLS certs for secure typha<->calico-node communication
+# typha_secure: false
+
+# Scaling typha: 1 replica per 100 nodes is adequate
+# Number of typha replicas
+# typha_replicas: 1
+
+# Set max typha connections
+# typha_max_connections_lower_limit: 300
+
+# Set calico network backend: "bird", "vxlan" or "none"
+# bird enable BGP routing, required for ipip and no encapsulation modes
+# calico_network_backend: vxlan
+
+# IP in IP and VXLAN is mutually exclusive modes.
+# set IP in IP encapsulation mode: "Always", "CrossSubnet", "Never"
+# calico_ipip_mode: 'Never'
+
+# set VXLAN encapsulation mode: "Always", "CrossSubnet", "Never"
+# calico_vxlan_mode: 'Always'
+
+# set VXLAN port and VNI
+# calico_vxlan_vni: 4096
+# calico_vxlan_port: 4789
+
+# Enable eBPF mode
+# calico_bpf_enabled: false
+
+# If you want to use non default IP_AUTODETECTION_METHOD, IP6_AUTODETECTION_METHOD for calico node set this option to one of:
+# * can-reach=DESTINATION
+# * interface=INTERFACE-REGEX
+# see https://docs.projectcalico.org/reference/node/configuration
+# calico_ip_auto_method: "interface=eth.*"
+# calico_ip6_auto_method: "interface=eth.*"
+
+# Set FELIX_MTUIFACEPATTERN, Pattern used to discover the host’s interface for MTU auto-detection.
+# see https://projectcalico.docs.tigera.io/reference/felix/configuration
+# calico_felix_mtu_iface_pattern: "^((en|wl|ww|sl|ib)[opsx].*|(eth|wlan|wwan).*)"
+
+# Choose the iptables insert mode for Calico: "Insert" or "Append".
+# calico_felix_chaininsertmode: Insert
+
+# If you want use the default route interface when you use multiple interface with dynamique route (iproute2)
+# see https://docs.projectcalico.org/reference/node/configuration : FELIX_DEVICEROUTESOURCEADDRESS
+# calico_use_default_route_src_ipaddr: false
+
+# Enable calico traffic encryption with wireguard
+# calico_wireguard_enabled: false
+
+# Under certain situations liveness and readiness probes may need tunning
+# calico_node_livenessprobe_timeout: 10
+# calico_node_readinessprobe_timeout: 10
+
+# Calico apiserver (only with kdd)
+# calico_apiserver_enabled: false

--- a/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -1,0 +1,264 @@
+---
+# cilium_version: "v1.12.1"
+
+# Log-level
+# cilium_debug: false
+
+# cilium_mtu: ""
+# cilium_enable_ipv4: true
+# cilium_enable_ipv6: false
+
+# Cilium agent health port
+# cilium_agent_health_port: "9879"
+
+# Identity allocation mode selects how identities are shared between cilium
+# nodes by setting how they are stored. The options are "crd" or "kvstore".
+# - "crd" stores identities in kubernetes as CRDs (custom resource definition).
+#   These can be queried with:
+#     `kubectl get ciliumid`
+# - "kvstore" stores identities in an etcd kvstore.
+# - In order to support External Workloads, "crd" is required
+#   - Ref: https://docs.cilium.io/en/stable/gettingstarted/external-workloads/#setting-up-support-for-external-workloads-beta
+# - KVStore operations are only required when cilium-operator is running with any of the below options:
+#   - --synchronize-k8s-services
+#   - --synchronize-k8s-nodes
+#   - --identity-allocation-mode=kvstore
+#   - Ref: https://docs.cilium.io/en/stable/internals/cilium_operator/#kvstore-operations
+# cilium_identity_allocation_mode: kvstore
+
+# Etcd SSL dirs
+# cilium_cert_dir: /etc/cilium/certs
+# kube_etcd_cacert_file: ca.pem
+# kube_etcd_cert_file: cert.pem
+# kube_etcd_key_file: cert-key.pem
+
+# Limits for apps
+# cilium_memory_limit: 500M
+# cilium_cpu_limit: 500m
+# cilium_memory_requests: 64M
+# cilium_cpu_requests: 100m
+
+# Overlay Network Mode
+# cilium_tunnel_mode: vxlan
+# Optional features
+# cilium_enable_prometheus: false
+# Enable if you want to make use of hostPort mappings
+# cilium_enable_portmap: false
+# Monitor aggregation level (none/low/medium/maximum)
+# cilium_monitor_aggregation: medium
+# The monitor aggregation flags determine which TCP flags which, upon the
+# first observation, cause monitor notifications to be generated.
+#
+# Only effective when monitor aggregation is set to "medium" or higher.
+# cilium_monitor_aggregation_flags: "all"
+# Kube Proxy Replacement mode (strict/partial)
+# cilium_kube_proxy_replacement: partial
+
+# If upgrading from Cilium < 1.5, you may want to override some of these options
+# to prevent service disruptions. See also:
+# http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
+# cilium_preallocate_bpf_maps: false
+
+# `cilium_tofqdns_enable_poller` is deprecated in 1.8, removed in 1.9
+# cilium_tofqdns_enable_poller: false
+
+# `cilium_enable_legacy_services` is deprecated in 1.6, removed in 1.9
+# cilium_enable_legacy_services: false
+
+# Unique ID of the cluster. Must be unique across all connected clusters and
+# in the range of 1 and 255. Only relevant when building a mesh of clusters.
+# This value is not defined by default
+# cilium_cluster_id:
+
+# Deploy cilium even if kube_network_plugin is not cilium.
+# This enables to deploy cilium alongside another CNI to replace kube-proxy.
+# cilium_deploy_additionally: false
+
+# Auto direct nodes routes can be used to advertise pods routes in your cluster
+# without any tunneling (with `cilium_tunnel_mode` sets to `disabled`).
+# This works only if you have a L2 connectivity between all your nodes.
+# You wil also have to specify the variable `cilium_native_routing_cidr` to
+# make this work. Please refer to the cilium documentation for more
+# information about this kind of setups.
+# cilium_auto_direct_node_routes: false
+
+# Allows to explicitly specify the IPv4 CIDR for native routing.
+# When specified, Cilium assumes networking for this CIDR is preconfigured and
+# hands traffic destined for that range to the Linux network stack without
+# applying any SNAT.
+# Generally speaking, specifying a native routing CIDR implies that Cilium can
+# depend on the underlying networking stack to route packets to their
+# destination. To offer a concrete example, if Cilium is configured to use
+# direct routing and the Kubernetes CIDR is included in the native routing CIDR,
+# the user must configure the routes to reach pods, either manually or by
+# setting the auto-direct-node-routes flag.
+# cilium_native_routing_cidr: ""
+
+# Allows to explicitly specify the IPv6 CIDR for native routing.
+# cilium_native_routing_cidr_ipv6: ""
+
+# Enable transparent network encryption.
+# cilium_encryption_enabled: false
+
+# Encryption method. Can be either ipsec or wireguard.
+# Only effective when `cilium_encryption_enabled` is set to true.
+# cilium_encryption_type: "ipsec"
+
+# Enable encryption for pure node to node traffic.
+# This option is only effective when `cilium_encryption_type` is set to `ipsec`.
+# cilium_ipsec_node_encryption: false
+
+# If your kernel or distribution does not support WireGuard, Cilium agent can be configured to fall back on the user-space implementation.
+# When this flag is enabled and Cilium detects that the kernel has no native support for WireGuard,
+# it will fallback on the wireguard-go user-space implementation of WireGuard.
+# This option is only effective when `cilium_encryption_type` is set to `wireguard`.
+# cilium_wireguard_userspace_fallback: false
+
+# IP Masquerade Agent
+# https://docs.cilium.io/en/stable/concepts/networking/masquerading/
+# By default, all packets from a pod destined to an IP address outside of the cilium_native_routing_cidr range are masqueraded
+# cilium_ip_masq_agent_enable: false
+
+### A packet sent from a pod to a destination which belongs to any CIDR from the nonMasqueradeCIDRs is not going to be masqueraded
+# cilium_non_masquerade_cidrs:
+#   - 10.0.0.0/8
+#   - 172.16.0.0/12
+#   - 192.168.0.0/16
+#   - 100.64.0.0/10
+#   - 192.0.0.0/24
+#   - 192.0.2.0/24
+#   - 192.88.99.0/24
+#   - 198.18.0.0/15
+#   - 198.51.100.0/24
+#   - 203.0.113.0/24
+#   - 240.0.0.0/4
+### Indicates whether to masquerade traffic to the link local prefix.
+### If the masqLinkLocal is not set or set to false, then 169.254.0.0/16 is appended to the non-masquerade CIDRs list.
+# cilium_masq_link_local: false
+### A time interval at which the agent attempts to reload config from disk
+# cilium_ip_masq_resync_interval: 60s
+
+# Hubble
+### Enable Hubble without install
+# cilium_enable_hubble: false
+### Enable Hubble Metrics
+# cilium_enable_hubble_metrics: false
+### if cilium_enable_hubble_metrics: true
+# cilium_hubble_metrics: {}
+# - dns
+# - drop
+# - tcp
+# - flow
+# - icmp
+# - http
+### Enable Hubble install
+# cilium_hubble_install: false
+### Enable auto generate certs if cilium_hubble_install: true
+# cilium_hubble_tls_generate: false
+
+# IP address management mode for v1.9+.
+# https://docs.cilium.io/en/v1.9/concepts/networking/ipam/
+# cilium_ipam_mode: kubernetes
+
+# Extra arguments for the Cilium agent
+# cilium_agent_custom_args: []
+
+# For adding and mounting extra volumes to the cilium agent
+# cilium_agent_extra_volumes: []
+# cilium_agent_extra_volume_mounts: []
+
+# cilium_agent_extra_env_vars: []
+
+# cilium_operator_replicas: 2
+
+# The address at which the cillium operator bind health check api
+# cilium_operator_api_serve_addr: "127.0.0.1:9234"
+
+## A dictionary of extra config variables to add to cilium-config, formatted like:
+##  cilium_config_extra_vars:
+##    var1: "value1"
+##    var2: "value2"
+# cilium_config_extra_vars: {}
+
+# For adding and mounting extra volumes to the cilium operator
+# cilium_operator_extra_volumes: []
+# cilium_operator_extra_volume_mounts: []
+
+# Extra arguments for the Cilium Operator
+# cilium_operator_custom_args: []
+
+# Name of the cluster. Only relevant when building a mesh of clusters.
+# cilium_cluster_name: default
+
+# Make Cilium take ownership over the `/etc/cni/net.d` directory on the node, renaming all non-Cilium CNI configurations to `*.cilium_bak`.
+# This ensures no Pods can be scheduled using other CNI plugins during Cilium agent downtime.
+# Available for Cilium v1.10 and up.
+# cilium_cni_exclusive: true
+
+# Configure the log file for CNI logging with retention policy of 7 days.
+# Disable CNI file logging by setting this field to empty explicitly.
+# Available for Cilium v1.12 and up.
+# cilium_cni_log_file: "/var/run/cilium/cilium-cni.log"
+
+# -- Configure cgroup related configuration
+# -- Enable auto mount of cgroup2 filesystem.
+# When `cilium_cgroup_auto_mount` is enabled, cgroup2 filesystem is mounted at
+# `cilium_cgroup_host_root` path on the underlying host and inside the cilium agent pod.
+# If users disable `cilium_cgroup_auto_mount`, it's expected that users have mounted
+# cgroup2 filesystem at the specified `cilium_cgroup_auto_mount` volume, and then the
+# volume will be mounted inside the cilium agent pod at the same path.
+# Available for Cilium v1.11 and up
+# cilium_cgroup_auto_mount: true
+# -- Configure cgroup root where cgroup2 filesystem is mounted on the host
+# cilium_cgroup_host_root: "/run/cilium/cgroupv2"
+
+# Specifies the ratio (0.0-1.0) of total system memory to use for dynamic
+# sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
+# cilium_bpf_map_dynamic_size_ratio: "0.0"
+
+# -- Enables masquerading of IPv4 traffic leaving the node from endpoints.
+# Available for Cilium v1.10 and up
+# cilium_enable_ipv4_masquerade: true
+# -- Enables masquerading of IPv6 traffic leaving the node from endpoints.
+# Available for Cilium v1.10 and up
+# cilium_enable_ipv6_masquerade: true
+
+# -- Enable native IP masquerade support in eBPF
+# cilium_enable_bpf_masquerade: false
+
+# -- Configure whether direct routing mode should route traffic via
+# host stack (true) or directly and more efficiently out of BPF (false) if
+# the kernel supports it. The latter has the implication that it will also
+# bypass netfilter in the host namespace.
+# cilium_enable_host_legacy_routing: true
+
+# -- Enable use of the remote node identity.
+# ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity
+# cilium_enable_remote_node_identity: true
+
+# -- Enable the use of well-known identities.
+# cilium_enable_well_known_identities: false
+
+# cilium_enable_bpf_clock_probe: true
+
+# -- Whether to enable CNP status updates.
+# cilium_disable_cnp_status_updates: true
+
+# A list of extra rules variables to add to clusterrole for cilium operator, formatted like:
+#   cilium_clusterrole_rules_operator_extra_vars:
+#     - apiGroups:
+#       - '""'
+#       resources:
+#       - pods
+#       verbs:
+#       - delete
+#     - apiGroups:
+#       - '""'
+#       resources:
+#       - nodes
+#       verbs:
+#       - list
+#       - watch
+#       resourceNames:
+#       - toto
+# cilium_clusterrole_rules_operator_extra_vars: []

--- a/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
@@ -1,0 +1,51 @@
+---
+# custom_cni network plugin configuration
+# There are two deployment options to choose from, select one
+
+## OPTION 1 - Static manifest files
+## With this option, referred manifest file will be deployed
+## as if the `kubectl apply -f` method was used with it.
+#
+## List of Kubernetes resource manifest files
+## See tests/files/custom_cni/README.md for example
+# custom_cni_manifests: []
+
+## OPTION 1 EXAMPLE - Cilium static manifests in Kubespray tree
+# custom_cni_manifests:
+#   - "{{ playbook_dir }}/../tests/files/custom_cni/cilium.yaml"
+
+## OPTION 2 - Helm chart application
+## This allows the CNI backend to be deployed to Kubespray cluster
+## as common Helm application.
+#
+## Helm release name - how the local instance of deployed chart will be named
+# custom_cni_chart_release_name: ""
+#
+## Kubernetes namespace to deploy into
+# custom_cni_chart_namespace: "kube-system"
+#
+## Helm repository name - how the local record of Helm repository will be named
+# custom_cni_chart_repository_name: ""
+#
+## Helm repository URL
+# custom_cni_chart_repository_url: ""
+#
+## Helm chart reference - path to the chart in the repository
+# custom_cni_chart_ref: ""
+#
+## Helm chart version
+# custom_cni_chart_version: ""
+#
+## Custom Helm values to be used for deployment
+# custom_cni_chart_values: {}
+
+## OPTION 2 EXAMPLE - Cilium deployed from official public Helm chart
+# custom_cni_chart_namespace: kube-system
+# custom_cni_chart_release_name: cilium
+# custom_cni_chart_repository_name: cilium
+# custom_cni_chart_repository_url: https://helm.cilium.io
+# custom_cni_chart_ref: cilium/cilium
+# custom_cni_chart_version: 1.14.3
+# custom_cni_chart_values:
+#   cluster:
+#     name: "cilium-demo"

--- a/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-flannel.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-flannel.yml
@@ -1,0 +1,18 @@
+# see roles/network_plugin/flannel/defaults/main.yml
+
+## interface that should be used for flannel operations
+## This is actually an inventory cluster-level item
+# flannel_interface:
+
+## Select interface that should be used for flannel operations by regexp on Name or IP
+## This is actually an inventory cluster-level item
+## example: select interface with ip from net 10.0.0.0/23
+## single quote and escape backslashes
+# flannel_interface_regexp: '10\\.0\\.[0-2]\\.\\d{1,3}'
+
+# You can choose what type of flannel backend to use: 'vxlan',  'host-gw' or 'wireguard'
+# please refer to flannel's docs : https://github.com/coreos/flannel/blob/master/README.md
+# flannel_backend_type: "vxlan"
+# flannel_vxlan_vni: 1
+# flannel_vxlan_port: 8472
+# flannel_vxlan_direct_routing: false

--- a/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-kube-ovn.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-kube-ovn.yml
@@ -1,0 +1,63 @@
+---
+
+# geneve or vlan
+kube_ovn_network_type: geneve
+
+# geneve, vxlan or stt. ATTENTION: some networkpolicy cannot take effect when using vxlan and stt need custom compile ovs kernel module
+kube_ovn_tunnel_type: geneve
+
+## The nic to support container network can be a nic name or a group of regex separated by comma e.g: 'enp6s0f0,eth.*', if empty will use the nic that the default route use.
+# kube_ovn_iface: eth1
+## The MTU used by pod iface in overlay networks (default iface MTU - 100)
+# kube_ovn_mtu: 1333
+
+## Enable hw-offload, disable traffic mirror and set the iface to the physical port. Make sure that there is an IP address bind to the physical port.
+kube_ovn_hw_offload: false
+# traffic mirror
+kube_ovn_traffic_mirror: false
+
+# kube_ovn_pool_cidr_ipv6: fd85:ee78:d8a6:8607::1:0000/112
+# kube_ovn_default_interface_name: eth0
+
+kube_ovn_external_address: 8.8.8.8
+kube_ovn_external_address_ipv6: 2400:3200::1
+kube_ovn_external_dns: alauda.cn
+
+# kube_ovn_default_gateway: 10.233.64.1,fd85:ee78:d8a6:8607::1:0
+kube_ovn_default_gateway_check: true
+kube_ovn_default_logical_gateway: false
+# kube_ovn_default_exclude_ips: 10.16.0.1
+kube_ovn_node_switch_cidr: 100.64.0.0/16
+kube_ovn_node_switch_cidr_ipv6: fd00:100:64::/64
+
+## vlan config, set default interface name and vlan id
+# kube_ovn_default_interface_name: eth0
+kube_ovn_default_vlan_id: 100
+kube_ovn_vlan_name: product
+
+## pod nic type, support: veth-pair or internal-port
+kube_ovn_pod_nic_type: veth_pair
+
+## Enable load balancer
+kube_ovn_enable_lb: true
+
+## Enable network policy support
+kube_ovn_enable_np: true
+
+## Enable external vpc support
+kube_ovn_enable_external_vpc: true
+
+## Enable checksum
+kube_ovn_encap_checksum: true
+
+## enable ssl
+kube_ovn_enable_ssl: false
+
+## dpdk
+kube_ovn_dpdk_enabled: false
+
+## enable interconnection to an existing IC database server.
+kube_ovn_ic_enable: false
+kube_ovn_ic_autoroute: true
+kube_ovn_ic_dbhost: "127.0.0.1"
+kube_ovn_ic_zone: "kubernetes"

--- a/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-kube-router.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-kube-router.yml
@@ -1,0 +1,73 @@
+# See roles/network_plugin/kube-router/defaults/main.yml
+
+# Kube router version
+# Default to v2
+# kube_router_version: "v2.0.0"
+# Uncomment to use v1 (Deprecated)
+# kube_router_version: "v1.6.0"
+
+# Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP
+# kube_router_run_router: true
+
+# Enables Network Policy -- sets up iptables to provide ingress firewall for pods
+# kube_router_run_firewall: true
+
+# Enables Service Proxy -- sets up IPVS for Kubernetes Services
+# see docs/kube-router.md "Caveats" section
+# kube_router_run_service_proxy: false
+
+# Add Cluster IP of the service to the RIB so that it gets advertises to the BGP peers.
+# kube_router_advertise_cluster_ip: false
+
+# Add External IP of service to the RIB so that it gets advertised to the BGP peers.
+# kube_router_advertise_external_ip: false
+
+# Add LoadBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
+# kube_router_advertise_loadbalancer_ip: false
+
+# Enables BGP graceful restarts
+# kube_router_bgp_graceful_restart: true
+
+# Adjust manifest of kube-router daemonset template with DSR needed changes
+# kube_router_enable_dsr: false
+
+# Array of arbitrary extra arguments to kube-router, see
+# https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md
+# kube_router_extra_args: []
+
+# ASN number of the cluster, used when communicating with external BGP routers
+# kube_router_cluster_asn: ~
+
+# ASN numbers of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr.
+# kube_router_peer_router_asns: ~
+
+# The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's.
+# kube_router_peer_router_ips: ~
+
+# The remote port of the external BGP to which all nodes will peer. If not set, default BGP port (179) will be used.
+# kube_router_peer_router_ports: ~
+
+# Setups node CNI to allow hairpin mode, requires node reboots, see
+# https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#hairpin-mode
+# kube_router_support_hairpin_mode: false
+
+# Select DNS Policy ClusterFirstWithHostNet, ClusterFirst, etc.
+# kube_router_dns_policy: ClusterFirstWithHostNet
+
+# Array of annotations for master
+# kube_router_annotations_master: []
+
+# Array of annotations for every node
+# kube_router_annotations_node: []
+
+# Array of common annotations for every node
+# kube_router_annotations_all: []
+
+# Enables scraping kube-router metrics with Prometheus
+# kube_router_enable_metrics: false
+
+# Path to serve Prometheus metrics on
+# kube_router_metrics_path: /metrics
+
+# Prometheus metrics port to use
+# kube_router_metrics_port: 9255

--- a/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-macvlan.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-macvlan.yml
@@ -1,0 +1,6 @@
+---
+# private interface, on a l2-network
+macvlan_interface: "eth1"
+
+# Enable nat in default gateway network interface
+enable_nat_default_gateway: true

--- a/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-weave.yml
+++ b/kubernetes-prod/inventory/sample/group_vars/k8s_cluster/k8s-net-weave.yml
@@ -1,0 +1,64 @@
+# see roles/network_plugin/weave/defaults/main.yml
+
+# Weave's network password for encryption, if null then no network encryption.
+# weave_password: ~
+
+# If set to 1, disable checking for new Weave Net versions (default is blank,
+# i.e. check is enabled)
+# weave_checkpoint_disable: false
+
+# Soft limit on the number of connections between peers. Defaults to 100.
+# weave_conn_limit: 100
+
+# Weave Net defaults to enabling hairpin on the bridge side of the veth pair
+# for containers attached. If you need to disable hairpin, e.g. your kernel is
+# one of those that can panic if hairpin is enabled, then you can disable it by
+# setting `HAIRPIN_MODE=false`.
+# weave_hairpin_mode: true
+
+# The range of IP addresses used by Weave Net and the subnet they are placed in
+# (CIDR format; default 10.32.0.0/12)
+# weave_ipalloc_range: "{{ kube_pods_subnet }}"
+
+# Set to 0 to disable Network Policy Controller (default is on)
+# weave_expect_npc: "{{ enable_network_policy }}"
+
+# List of addresses of peers in the Kubernetes cluster (default is to fetch the
+# list from the api-server)
+# weave_kube_peers: ~
+
+# Set the initialization mode of the IP Address Manager (defaults to consensus
+# amongst the KUBE_PEERS)
+# weave_ipalloc_init: ~
+
+# Set the IP address used as a gateway from the Weave network to the host
+# network - this is useful if you are configuring the addon as a static pod.
+# weave_expose_ip: ~
+
+# Address and port that the Weave Net daemon will serve Prometheus-style
+# metrics on (defaults to 0.0.0.0:6782)
+# weave_metrics_addr: ~
+
+# Address and port that the Weave Net daemon will serve status requests on
+# (defaults to disabled)
+# weave_status_addr: ~
+
+# Weave Net defaults to 1376 bytes, but you can set a smaller size if your
+# underlying network has a tighter limit, or set a larger size for better
+# performance if your network supports jumbo frames (e.g. 8916)
+# weave_mtu: 1376
+
+# Set to 1 to preserve the client source IP address when accessing Service
+# annotated with `service.spec.externalTrafficPolicy=Local`. The feature works
+# only with Weave IPAM (default).
+# weave_no_masq_local: true
+
+# set to nft to use nftables backend for iptables (default is iptables)
+# weave_iptables_backend: iptables
+
+# Extra variables that passing to launch.sh, useful for enabling seed mode, see
+# https://www.weave.works/docs/net/latest/tasks/ipam/ipam/
+# weave_extra_args: ~
+
+# Extra variables for weave_npc that passing to launch.sh, useful for change log level, ex --log-level=error
+# weave_npc_extra_args: ~

--- a/kubernetes-prod/inventory/sample/inventory.ini
+++ b/kubernetes-prod/inventory/sample/inventory.ini
@@ -1,0 +1,47 @@
+# ## Configure 'ip' variable to bind kubernetes services on a
+# ## different ip than the default iface
+# ## We should set etcd_member_name for etcd cluster. The node that is not a etcd member do not need to set the value, or can set the empty string value.
+[all]
+# node1 ansible_host=95.54.0.12  # ip=10.3.0.1 etcd_member_name=etcd1
+# node2 ansible_host=95.54.0.13  # ip=10.3.0.2 etcd_member_name=etcd2
+# node3 ansible_host=95.54.0.14  # ip=10.3.0.3 etcd_member_name=etcd3
+# node4 ansible_host=95.54.0.15  # ip=10.3.0.4 etcd_member_name=etcd4
+# node5 ansible_host=95.54.0.16  # ip=10.3.0.5 etcd_member_name=etcd5
+# node6 ansible_host=95.54.0.17  # ip=10.3.0.6 etcd_member_name=etcd6
+
+master   ansible_host=192.168.1.100  ip=192.168.1.100 etcd_member_name=etcd1
+worker-1 ansible_host=192.168.1.201  ip=192.168.1.201 
+worker-2 ansible_host=192.168.1.202  ip=192.168.1.202 
+worker-3 ansible_host=192.168.1.203  ip=192.168.1.203 
+# ## configure a bastion host if your nodes are not directly reachable
+# [bastion]
+# bastion ansible_host=x.x.x.x ansible_user=some_user
+
+[kube_control_plane]
+# node1
+# node2
+# node3
+master
+
+[etcd]
+# node1
+# node2
+# node3
+master
+
+[kube_node]
+# node2
+# node3
+# node4
+# node5
+# node6
+worker-1
+worker-2
+worker-3
+
+[calico_rr]
+
+[k8s_cluster:children]
+kube_control_plane
+kube_node
+calico_rr

--- a/kubernetes-prod/inventory/sample/patches/kube-controller-manager+merge.yaml
+++ b/kubernetes-prod/inventory/sample/patches/kube-controller-manager+merge.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '10257'

--- a/kubernetes-prod/inventory/sample/patches/kube-scheduler+merge.yaml
+++ b/kubernetes-prod/inventory/sample/patches/kube-scheduler+merge.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-scheduler
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '10259'

--- a/kubernetes-prod/nginx.yaml
+++ b/kubernetes-prod/nginx.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 4
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.17.2
+        ports:
+        - containerPort: 80

--- a/kubernetes-prod/tf/main.tf
+++ b/kubernetes-prod/tf/main.tf
@@ -1,0 +1,89 @@
+locals {
+  folder_id = "b1gnh3c0khmhhi97erbd"
+}
+
+resource "yandex_vpc_network" "akha-k8s-prod" {
+  name = "akha-k8s-prod"
+}
+
+resource "yandex_vpc_subnet" "akha-k8s-prod" {
+  name           = "akha-k8s-prod"
+  zone           = "ru-central1-a"
+  network_id     = yandex_vpc_network.akha-k8s-prod.id
+  v4_cidr_blocks = ["192.168.1.0/24"]
+  route_table_id = yandex_vpc_route_table.rt.id
+}
+
+resource "yandex_vpc_gateway" "egress" {
+  name = "egress"
+  shared_egress_gateway {}
+}
+
+resource "yandex_vpc_route_table" "rt" {
+  name       = "rt"
+  network_id = yandex_vpc_network.akha-k8s-prod.id
+
+  static_route {
+    destination_prefix = "0.0.0.0/0"
+    gateway_id         = yandex_vpc_gateway.egress.id
+  }
+}
+
+resource "yandex_compute_instance" "master" {
+  name     = "master"
+  hostname = "master"
+  resources {
+    cores         = 2
+    memory        = 8
+    core_fraction = 20
+  }
+
+  boot_disk {
+    initialize_params {
+      image_id = "fd85an6q1o26nf37i2nl"
+      size     = 20
+    }
+  }
+
+  network_interface {
+    ip_address     = "192.168.1.100"
+    ipv6           = false
+    nat            = true
+    nat_ip_address = "62.84.119.214"
+    subnet_id      = yandex_vpc_subnet.akha-k8s-prod.id
+  }
+
+  metadata = {
+    ssh-keys = "ubuntu:${file("~/.ssh/akha-yc.pub")}"
+  }
+}
+
+resource "yandex_compute_instance" "worker" {
+  count    = 3
+  name     = "worker-${count.index + 1}"
+  hostname = "worker-${count.index + 1}"
+
+  resources {
+    cores         = 2
+    memory        = 8
+    core_fraction = 20
+  }
+
+  boot_disk {
+    initialize_params {
+      image_id = "fd85an6q1o26nf37i2nl"
+      size     = 20
+    }
+  }
+
+  network_interface {
+    subnet_id  = yandex_vpc_subnet.akha-k8s-prod.id
+    nat        = false
+    ip_address = "192.168.1.20${count.index + 1}"
+    ipv6       = false
+  }
+
+  metadata = {
+    ssh-keys = "ubuntu:${file("~/.ssh/akha-yc.pub")}"
+  }
+}

--- a/kubernetes-prod/tf/provider.tf
+++ b/kubernetes-prod/tf/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.1.6"
+
+  required_providers {
+    yandex = {
+      source  = "yandex-cloud/yandex"
+      version = "> 0.90.0"
+    }
+  }
+}
+provider "yandex" {
+  service_account_key_file = file("/home/akha/key.json")
+  cloud_id                 = "b1g5fjugjkch6hcqqnok"
+  folder_id                = "b1gnh3c0khmhhi97erbd"
+  zone                     = "ru-central1-a"
+}


### PR DESCRIPTION
/--------------------------------------------------------------
# akharc_platform
akharc Platform repository
# Выполнено ДЗ №14

 - [x] Основное ДЗ
 - [ ] Задание со * 


## В процессе сделано:
 - развернут кластер версии 1.23 и затем обновлен
 - развернут кластер через kubespray



## Как проверить работоспособность:

### Готовим инфраструктуру:

- Настраиваем терраформ на работу с ЯОблаком
``` shell
yc iam key create \
  --service-account-id <идентификатор_сервисного_аккаунта> \
  --folder-name <имя_каталога_с_сервисным_аккаунтом> \
  --output key.json

id: *значение*
service_account_id: *значение*
created_at: "2024-02-24T12:22:14.241173512Z"
key_algorithm: RSA_2048

[akha@192 ~]$ yc config profile create akha-k8s-tf
Profile 'akha-k8s-tf' created and activated

yc config set service-account-key key.json
yc config set cloud-id *значение*
yc config set folder-id *значение*

export YC_TOKEN=$(yc iam create-token)
export YC_CLOUD_ID=$(yc config get cloud-id)
export YC_FOLDER_ID=$(yc config get folder-id)
```

- выбираем образ    
``` shell
yc compute image list --folder-id standard-images  | grep ubuntu-20-04

export PATH=$PATH:/usr/local/src

| fd85an6q1o26nf37i2nl | ubuntu-20-04-lts-v20231218                                 | ubuntu-2004-lts                                 | f2ekp29fd7vk7pke4hj5           | READY  |
```
 - далее ставим Terraform из зеркала Яндекса, делаем terraform init и разворачиваем ноды
``` shell
[akha@192 tf]$ terraform init

[akha@192 tf]$ terraform plan
[akha@192 tf]$ terraform apply --auto-approve

master_hostname = "master"
master_private_ip = "192.168.1.100"
master_public_ip = "XXXX"
worker_nodes_hostnames = [
  "worker-1",
  "worker-2",
  "worker-3",
]
worker_nodes_private_ips = [
  "192.168.1.201",
  "192.168.1.202",
  "192.168.1.203",
]
``` 

 - Настраиваем подключение по ssh к мастер-ноде и к воркерам, мастер выступает в роли jump-хоста
добавляем в ~/.ssh/config параметры подключения к мастеру и заходим на него
``` shell
echo '62.84.119.214 master kubernetes' | sudo tee -a /etc/hosts
ssh master
``` 
на мастере добавляем в ~/.ssh/config параметры подключения к воркерам, подкидывваем ssh-ключ и правим /etc/hosts
``` shell
# Your system has configured 'manage_etc_hosts' as True.
# As a result, if you wish for changes to this file to persist
# then you will need to either
# a.) make changes to the master file in /etc/cloud/templates/hosts.debian.tmpl
# b.) change or remove the value of 'manage_etc_hosts' in
#     /etc/cloud/cloud.cfg or cloud-config from user-data
#
127.0.1.1 master.ru-central1.internal master
127.0.0.1 localhost

# The following lines are desirable for IPv6 capable hosts
::1 localhost ip6-localhost ip6-loopback
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
192.168.1.100 master
192.168.1.201 worker-1
192.168.1.202 worker-2
192.168.1.203 worker-3
```

далее актуализируем /etc/hosts на воркерах

### Подготовка машин

#### Отключаем свап
```shell
ubuntu@master:~$ sudo sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
ubuntu@master:~$ sudo swapoff -a
```
#### Загрузим br_netfilter и позволим iptables видеть трафик.

на всех машинах:
```shell
$ cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
overlay
br_netfilter
EOF

$ sudo modprobe overlay
$ sudo modprobe br_netfilter

$ cat <<EOF | sudo tee /etc/sysctl.d/kubernetes.conf
net.bridge.bridge-nf-call-iptables=1 
net.ipv4.ip_forward=1 
net.bridge.bridge-nf-call-ip6tables=1 
EOF

$ sudo sysctl --system
```
#### Установим Containerd
на всех машинах:
```shell
$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
$ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
$ sudo apt update -y
$ sudo apt install -y containerd.io
$ sudo mkdir -p /etc/containerd
$ containerd config default | sudo tee /etc/containerd/config.toml
$ sudo systemctl restart containerd && sudo systemctl enable containerd
```
#### Установка kubectl, kubeadm, kubelet
на всех машинах:
```shell
$ sudo apt-get update && sudo apt-get install -y apt-transport-https curl
$ curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
$ echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
$ sudo apt update -y
$ sudo apt -y install vim git curl wget kubelet=1.23.0-00 kubeadm=1.23.0-00 kubectl=1.23.0-00
$ sudo apt-mark hold kubelet kubeadm kubectl
$ sudo kubeadm config images pull --cri-socket /run/containerd/containerd.sock --kubernetes-version v1.23.0
```

### Создание кластера

на мастер-ноде
``` shell
sudo kubeadm init \
  --apiserver-cert-extra-sans 62.84.119.214 \
  --pod-network-cidr=10.244.0.0/16 \
  --upload-certs \
  --kubernetes-version=v1.23.0 \
  --cri-socket /run/containerd/containerd.sock

...  
Your Kubernetes control-plane has initialized successfully!

To start using your cluster, you need to run the following as a regular user:

  mkdir -p $HOME/.kube
  sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
  sudo chown $(id -u):$(id -g) $HOME/.kube/config

Alternatively, if you are the root user, you can run:

  export KUBECONFIG=/etc/kubernetes/admin.conf

You should now deploy a pod network to the cluster.
Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
  https://kubernetes.io/docs/concepts/cluster-administration/addons/

Then you can join any number of worker nodes by running the following on each as root:
```
```shell
kubeadm join 192.168.1.100:6443 --token token \
        --discovery-token-ca-cert-hash sha256:hash
```
 - Копируем конфиг kubectl
```shell
mkdir -p $HOME/.kube
sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
sudo chown $(id -u):$(id -g) $HOME/.kube/config

[akha@192 .kube]$ kubectl cluster-info
Kubernetes control plane is running at https://master:6443
CoreDNS is running at https://master:6443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
```shell

#### Установим сетевой плагин
```shell
ubuntu@master:~$ kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml
namespace/kube-flannel created
clusterrole.rbac.authorization.k8s.io/flannel created
clusterrolebinding.rbac.authorization.k8s.io/flannel created
serviceaccount/flannel created
configmap/kube-flannel-cfg created
daemonset.apps/kube-flannel-ds created

ubuntu@master:~$ kubectl get nodes -o wide
NAME     STATUS   ROLES                  AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
master   Ready 
```
#### Подключаем worker-ноды

получаем токен на мастере:
```shell
ubuntu@master:~$ sudo kubeadm token create --print-join-command
```
Выполняем на каждом воркере:
```shell
sudo kubeadm join master:6443 --token токен --discovery-token-ca-cert-hash sha256:хешш

ubuntu@master:~$ kubectl get nodes -o wide
NAME       STATUS 
master     Ready    
worker-1   Ready    
worker-2   Ready    
worker-3   Ready 
```shell
#### Запуск нагрузки
```shell
[akha@192 kubernetes-prod]$ kubectl apply -f nginx.yaml
[akha@192 kubernetes-prod]$ kubectl get pods -o wide
NAME                             READY   STATUS    RESTARTS   AGE   IP           NODE       NOMINATED NODE   READINESS GATES
nginx-deployment-8c9c5f4-6xq64   1/1     Running   0          33s   10.244.1.2   worker-1   <none>           <none>
nginx-deployment-8c9c5f4-pnsx4   1/1     Running   0          33s   10.244.2.2   worker-2   <none>           <none>
nginx-deployment-8c9c5f4-qczr9   1/1     Running   0          33s   10.244.3.2   worker-3   <none>           <none>
nginx-deployment-8c9c5f4-zdtcz   1/1     Running   0          33s   10.244.3.3   worker-3   <none>           <none>
```
### Обновление кластера
Сперва мастер, затем - воркеры
#### Обновление мастера
```shell
$ sudo apt update
$ apt-cache madison kubeadm
$ sudo apt-get install kubeadm='1.24.17-00' \
  -y \
  --allow-change-held-packages
$ sudo kubeadm upgrade plan
$ sudo kubeadm upgrade apply v1.24.17
[upgrade/successful] SUCCESS! Your cluster was upgraded to "v1.24.17". Enjoy!

[upgrade/kubelet] Now that your control plane is upgraded, please proceed with upgrading your kubelets if you haven't already done so.
```

Версия kubelet не изменилась
```shell
ubuntu@master:~$ kubectl get nodes
NAME       STATUS   ROLES           AGE     VERSION
master     Ready    control-plane   2d22h   v1.23.0
worker-1   Ready    <none>          2d22h   v1.23.0
worker-2   Ready    <none>          2d22h   v1.23.0
worker-3   Ready    <none>          2d22h   v1.23.0
```shell
Версия Api изменилась:
```shell
ubuntu@master:~$ kubectl version
Server Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.17"
```
#### Обновление остальных компонентов кластера
```shell
root@master:/home/ubuntu# kubeadm upgrade plan
...
[upgrade/versions] Target version: v1.24.17
[upgrade/versions] Latest version in the v1.24 series: v1.24.17
```
 - применяем изменения:
```shell
kubeadm upgrade apply v1.24.17
[upgrade/successful] SUCCESS! Your cluster was upgraded to "v1.24.17". Enjoy!
root@master:/home/ubuntu# kubeadm version
kubeadm version: &version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.17", GitCommit:"22a9682c8fe855c321be75c5faacde343f909b04", GitTreeState:"clean", BuildDate:"2023-08-23T23:43:11Z", GoVersion:"go1.20.7", Compiler:"gc", Platform:"linux/amd64"}
root@master:/home/ubuntu# kubelet --version
Kubernetes v1.23.0
```
 - Обновим kubelet
```shell
sudo apt-get install kubelet='1.24.17-00' kubectl='1.24.17-00' \
  -y \
  --allow-change-held-packages 
sudo systemctl daemon-reload
sudo systemctl restart kubelet
ubuntu@master:~$ kubectl get nodes
NAME       STATUS   ROLES           AGE     VERSION
master     Ready    control-plane   2d22h   v1.24.17
worker-1   Ready    <none>          2d22h   v1.23.0
worker-2   Ready    <none>          2d22h   v1.23.0
worker-3   Ready    <none>          2d22h   v1.23.0
```
#### Обновление worker nodes

Операции выполняем на каждой из worker нод. Обновляем по очереди, сначала полностью одну ноду, и, после ее ввода в срой, - обновляем следующую.

снимаем нагрузку с ноды:
```shell
[akha@192 ~]$ kubectl drain worker-1 --ignore-daemonsets

...
node/worker-1 drained
[akha@192 ~]$ kubectl get nodes
NAME       STATUS                     ROLES           AGE     VERSION
master     Ready                      control-plane   2d23h   v1.24.17
worker-1   Ready,SchedulingDisabled   <none>          2d22h   v1.23.0
```

Обновляем kubeadm:
```shell
$ sudo apt update
$ apt-cache madison kubeadm
$ sudo apt-get install kubeadm='1.24.17-00' \
  -y \
  --allow-change-held-packages
$ sudo kubeadm upgrade node
[upgrade] The configuration for this node was successfully updated!
```
обновляем kubelet
```shell
$ sudo apt-get install kubelet='1.24.17-00' kubectl='1.24.17-00' \
  -y \
  --allow-change-held-packages
$ sudo systemctl daemon-reload
$ sudo systemctl restart kubelet
```
возвращаем нагрузку
```shell
[akha@192 ~]$ kubectl uncordon worker-1
node/worker-1 uncordoned
```
Смотрим результат

```shell
[akha@192 ~]$ kubectl get nodes
NAME       STATUS   ROLES           AGE     VERSION
master     Ready    control-plane   2d23h   v1.24.17
worker-1   Ready    <none>          2d23h   v1.24.17
worker-2   Ready    <none>          2d22h   v1.23.0
worker-3   Ready    <none>          2d22h   v1.23.0
```
повторяем на оставшихся двух нодах.
```shell
[akha@192 ~]$ kubectl get nodes
NAME       STATUS   ROLES           AGE     VERSION
master     Ready    control-plane   2d23h   v1.24.17
worker-1   Ready    <none>          2d23h   v1.24.17
worker-2   Ready    <none>          2d23h   v1.24.17
worker-3   Ready    <none>          2d23h   v1.24.17
```
### Автоматическое развертывание кластеров

Ставим python и pip
```shell
[akha@192 ~]$ sudo yum-install python3
[akha@192 ~]$ sudo yum install pip
[akha@192 ~]$ python3 -V
Python 3.9.18
[akha@192 ~]$ pip -V
pip 21.2.3 from /usr/lib/python3.9/site-packages/pip (python 3.9)
[akha@192 ~]$ pip3 install virtualenv
```
Пересоздаем ноды терраформом, назначем им внешние адреса.
SSH доступ на все ноды кластера - аналогично ручному развертыванию. 
#### Установка Kubespray
```shell
[akha@192 ~]$ git clone https://github.com/kubernetes-sigs/kubespray.git
[akha@192 kubespray]$ sudo pip install -r requirements.txt
[akha@192 kubespray]$ ansible --version
ansible [core 2.15.9]
  config file = /home/akha/kubespray/ansible.cfg
  configured module search path = ['/home/akha/kubespray/library']
  ansible python module location = /usr/local/lib/python3.9/site-packages/ansible
  ansible collection location = /home/akha/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.9.18 (main, Jan 24 2024, 00:00:00) [GCC 11.4.1 20231218 (Red Hat 11.4.1-3)] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
```
 - копируем и правим iventory
```shell
mkdir -p kubernetes-prod/inventory/
```
Запускаем созадние кластера
```shell
ansible-playbook \
  -i ~/kubernetes-prod/inventory/inventory.ini \
  --become \
  --become-user=root \
  --user=ubuntu \
  --key-file=/home/akha/.ssh/akha-yc cluster.yml
```
 - A few moments later ...  
```shell
PLAY RECAP ***********************************************************************************************************************************************
master                     : ok=698  changed=144  unreachable=0    failed=0    skipped=1165 rescued=0    ignored=6
worker-1                   : ok=438  changed=88   unreachable=0    failed=0    skipped=697  rescued=0    ignored=1
worker-2                   : ok=438  changed=88   unreachable=0    failed=0    skipped=693  rescued=0    ignored=1
worker-3                   : ok=438  changed=88   unreachable=0    failed=0    skipped=693  rescued=0    ignored=1
```
Далее на мастере настраиваем конфиг:
```shell
mkdir -p $HOME/.kube
sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
sudo chown $(id -u):$(id -g) $HOME/.kube/config
```
и получаем инфу о нодах:
```shell
ubuntu@master:~$ kubectl get nodes -o wide
NAME       STATUS   ROLES           AGE     VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
master     Ready    control-plane   8m35s   v1.29.2   192.168.1.100   <none>        Ubuntu 20.04.6 LTS   5.4.0-169-generic   containerd://1.7.13
worker-1   Ready    <none>          7m54s   v1.29.2   192.168.1.201   <none>        Ubuntu 20.04.6 LTS   5.4.0-169-generic   containerd://1.7.13
worker-2   Ready    <none>          7m54s   v1.29.2   192.168.1.202   <none>        Ubuntu 20.04.6 LTS   5.4.0-169-generic   containerd://1.7.13
worker-3   Ready    <none>          7m49s   v1.29.2   192.168.1.203   <none>        Ubuntu 20.04.6 LTS   5.4.0-169-generic   containerd://1.7.13
```
 - подаем нагрузку и проверяем:
```shell
[akha@192 kubernetes-prod]$ kubectl apply -f nginx.yaml
deployment.apps/nginx-deployment created

[akha@192 kubernetes-prod]$ kubectl get po -o wide
NAME                                READY   STATUS    RESTARTS   AGE   IP               NODE       NOMINATED NODE   READINESS GATES
nginx-deployment-54b6986c8c-9c25d   1/1     Running   0          79s   10.233.105.194   worker-1   <none>           <none>
nginx-deployment-54b6986c8c-9wkx5   1/1     Running   0          79s   10.233.72.193    worker-2   <none>           <none>
nginx-deployment-54b6986c8c-v5ngp   1/1     Running   0          79s   10.233.72.194    worker-2   <none>           <none>
nginx-deployment-54b6986c8c-zt5lk   1/1     Running   0          79s   10.233.125.66    worker-3   <none>           <none>

```
## PR checklist:
 - [*] Выставлен label с темой домашнего задания

